### PR TITLE
Added margin bottom to input component

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -117,6 +117,7 @@ const Label = styled.label`
 const LabelText = styled.span`
   display: inline-block;
   color: ${color.spaceMedium};
+  margin-bottom: ${space[16]};
 `
 
 export const Adornment = styled.span`


### PR DESCRIPTION
# Description

Talked with @jimzarkadas about the margin between the label and the input and decided to go with a `margin-bottom` of `8px` to align with our current Website project.

## Changes

- [x] Add margin-bottom

## How to test

- Checkout this branch
- `$ npm run storybook`
- Checkout the `Input` component

## Screenshots

<img width="1721" alt="screenshot 2019-01-10 at 16 28 09" src="https://user-images.githubusercontent.com/14276144/50978470-c8813f00-14f4-11e9-891f-44f1790254d0.png">

## To be notified

@jimzarkadas 
