### PR TITLE
Disable hyphenation for input and textarea elements

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -34,7 +34,9 @@ const Field = styled.input`
   padding-bottom: ${props => (props.as === 'textarea' ? space[12] : 0)};
   padding-left: ${props => (props.leftAdornment ? space[48] : space[16])};
   padding-right: ${props =>
-    props.onReset || props.loading ? space[48] : space[16]};
+    (props.value && props.value.length && props.onReset) || props.loading
+      ? space[48]
+      : space[16]};
   color: ${props => (props.invalid ? color.mars : color.space)};
   border: 1px solid ${color.stardust};
   box-shadow: none;

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -77,6 +77,8 @@ export const GlobalStyles = createGlobalStyle`
   abbr,
   acronym,
   blockquote,
+  input,
+  textarea,
   q {
     hyphens: none;
   }


### PR DESCRIPTION
# Description

Hyphenation caused ugly line-breaks inside input elements, this fixes it. Also adjusts the right padding of input elements when the field doesn't have a value.