### PR TITLE
Update global CSS reset

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,8 +1,12 @@
 import React from 'react'
-import { GlobalStyles } from '../src/global-styles'
+import { createGlobalStyle } from 'styled-components'
+import { globalStyles } from '../src/global-styles'
 import { configure, addDecorator } from '@storybook/react'
 
 const req = require.context('../src/components', true, /\.stories\.js$/)
+const GlobalStyles = createGlobalStyle`
+  ${globalStyles};
+`
 
 function loadStories() {
   req.keys().forEach(filename => req(filename))

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,0 @@
-<html class="fonts-loaded">

--- a/src/components/Alert/index.js
+++ b/src/components/Alert/index.js
@@ -45,7 +45,6 @@ const Main = styled.div`
 `
 
 const Message = styled.p`
-  margin: 0;
   color: ${color.space};
   padding-top: ${space[16]};
   padding-bottom: ${space[16]};

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -44,17 +44,11 @@ const StyledBanner = styled.a`
   }
 `
 
-const ChildrenContainer = styled(Box)`
-  & * {
-    margin: 0;
-  }
-`
-
 export const Banner = ({ backgroundImageUrl, children, url, ...props }) => {
   return (
     <StyledBanner backgroundImageUrl={backgroundImageUrl} href={url} {...props}>
       <Box display="flex" justifyContent="space-between" alignItems="center">
-        <ChildrenContainer>{children}</ChildrenContainer>
+        <div>{children}</div>
         <Box display="flex" justifyContent="flex-end" alignItems="center">
           <Icon glyph="arrow-right" />
         </Box>

--- a/src/components/CustomDropdown/index.js
+++ b/src/components/CustomDropdown/index.js
@@ -15,9 +15,7 @@ import {
 export const Menu = styled.ul`
   position: absolute;
   z-index: 2;
-  margin: 0;
   padding: ${space[16]};
-  list-style: none;
   left: 50%;
   transform: translateX(-50%);
   border-radius: ${radius.md};

--- a/src/components/Heading/index.js
+++ b/src/components/Heading/index.js
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { color, device, fontSize, fontWeight, lineHeight } from '../../theme'
 
 export const H1 = styled.h1`
-  margin: 0;
   font-weight: ${fontWeight.bold};
   font-size: ${fontSize[28]};
   line-height: ${lineHeight.title};
@@ -13,7 +12,6 @@ export const H1 = styled.h1`
 `
 
 export const H2 = styled.h2`
-  margin: 0;
   font-weight: ${fontWeight.semiBold};
   font-size: ${fontSize[24]};
   line-height: ${lineHeight.title};
@@ -24,7 +22,6 @@ export const H2 = styled.h2`
 `
 
 export const H3 = styled.h3`
-  margin: 0;
   font-weight: ${fontWeight.regular};
   font-size: ${fontSize[20]};
   line-height: ${lineHeight.title};
@@ -35,7 +32,6 @@ export const H3 = styled.h3`
 `
 
 export const H4 = styled.h4`
-  margin: 0;
   font-weight: ${fontWeight.regular};
   font-size: ${fontSize[18]};
   line-height: ${lineHeight.title};
@@ -46,7 +42,6 @@ export const H4 = styled.h4`
 `
 
 export const H5 = styled.h5`
-  margin: 0;
   font-weight: ${fontWeight.regular};
   font-size: ${fontSize[14]};
 
@@ -56,7 +51,6 @@ export const H5 = styled.h5`
 `
 
 export const H6 = styled.h6`
-  margin: 0;
   font-weight: ${fontWeight.semiBold};
   font-size: ${fontSize[12]};
   text-transform: uppercase;

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -1,53 +1,66 @@
-import { createGlobalStyle } from 'styled-components'
-import { fontWeight, device, space, fontSize, lineHeight, color } from './theme'
+import { css } from 'styled-components'
+import { fontWeight, device, fontSize, lineHeight, color } from './theme'
 
-export const GlobalStyles = createGlobalStyle`
+export const globalStyles = css`
   @font-face {
-    font-family: "Proxima Nova";
-    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularWeb.woff2') format('woff2'),
-         url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularWeb.woff') format('woff');
+    font-family: 'Proxima Nova';
+    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularWeb.woff2')
+        format('woff2'),
+      url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularWeb.woff')
+        format('woff');
     font-weight: ${fontWeight.regular};
     font-style: normal;
     font-display: swap;
   }
 
   @font-face {
-    font-family: "Proxima Nova";
-    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularItWeb.woff2') format('woff2'),
-         url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularItWeb.woff') format('woff');
+    font-family: 'Proxima Nova';
+    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularItWeb.woff2')
+        format('woff2'),
+      url('https://cdn.ticketswap.com/static/fonts/ProximaNova-RegularItWeb.woff')
+        format('woff');
     font-weight: ${fontWeight.regular};
     font-style: italic;
     font-display: swap;
   }
 
   @font-face {
-    font-family: "Proxima Nova";
-    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-SemiboldWeb.woff2') format('woff2'),
-         url('https://cdn.ticketswap.com/static/fonts/ProximaNova-SemiboldWeb.woff') format('woff');
+    font-family: 'Proxima Nova';
+    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-SemiboldWeb.woff2')
+        format('woff2'),
+      url('https://cdn.ticketswap.com/static/fonts/ProximaNova-SemiboldWeb.woff')
+        format('woff');
     font-weight: ${fontWeight.semiBold};
     font-style: normal;
     font-display: swap;
   }
 
   @font-face {
-    font-family: "Proxima Nova";
-    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-BoldWeb.woff2') format('woff2'),
-         url('https://cdn.ticketswap.com/static/fonts/ProximaNova-BoldWeb.woff') format('woff');
+    font-family: 'Proxima Nova';
+    src: url('https://cdn.ticketswap.com/static/fonts/ProximaNova-BoldWeb.woff2')
+        format('woff2'),
+      url('https://cdn.ticketswap.com/static/fonts/ProximaNova-BoldWeb.woff')
+        format('woff');
     font-weight: ${fontWeight.bold};
     font-style: normal;
     font-display: swap;
   }
 
-  *, *:before, *:after {
+  *,
+  *:before,
+  *:after {
     box-sizing: border-box;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    margin: 0;
+    padding: 0;
+    border: 0;
   }
 
   body {
-    margin: 0;
-    padding: 0;
-    font-family: 'Proxima Nova', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif;
+    font-family: 'Proxima Nova', -apple-system, BlinkMacSystemFont,
+      'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto,
+      'segoe ui', arial, sans-serif;
     font-weight: ${fontWeight.regular};
     line-height: ${lineHeight.copy};
     font-size: ${fontSize[16]};
@@ -81,11 +94,6 @@ export const GlobalStyles = createGlobalStyle`
     color: ${color.earth};
   }
 
-  p {
-    margin-top: 0;
-    margin-bottom: ${space[32]};
-  }
-
   button {
     padding: 0;
     margin: 0;
@@ -94,5 +102,37 @@ export const GlobalStyles = createGlobalStyle`
     color: inherit;
     background-color: transparent;
     cursor: pointer;
+  }
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+  }
+
+  img {
+    border-style: none;
+  }
+
+  blockquote,
+  q {
+    quotes: none;
+  }
+
+  blockquote:after,
+  blockquote:before,
+  q:after,
+  q:before {
+    content: '';
+    content: none;
   }
 `

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export {
   DialogFooter,
 } from './components/Dialog'
 export { Flag } from './components/Flag'
-export { GlobalStyles } from './global-styles'
+export { globalStyles } from './global-styles'
 export { H1, H2, H3, H4, H5, H6 } from './components/Heading'
 export { HorizontalScroll } from './components/HorizontalScroll'
 export { Icon } from './components/Icon'


### PR DESCRIPTION
This adds a more opinionated CSS reset than the one we previously used. All default margins,  paddings and a few other properties are now reset to `0`. After working with Solar for a while, I’ve noticed that adding a global reset like that is the more efficient approach. 99% of the time, we don’t need default styles in the UI’s we’re building.

BREAKING CHANGE: Instead of exporting a `<GlobalStyles />` component, Solar now exports a template literal for global styles which can be extended more easily.