### PR TITLE
fix(Dialog): Address wrong flex-shrink behaviour in Firefox

### DIFF
--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -82,6 +82,7 @@ export const DialogAdornment = styled.span`
 
 const BodyContainer = styled.div`
   position: relative;
+  min-height: 0;
   flex-shrink: 1;
   display: flex;
   flex-direction: column;
@@ -124,7 +125,6 @@ export const Body = styled.div`
   position: relative;
   padding: ${space[16]};
   overflow-y: scroll;
-  flex-shrink: 1;
   -webkit-overflow-scrolling: touch;
 
   ::-webkit-scrollbar {

--- a/src/components/Dialog/index.stories.js
+++ b/src/components/Dialog/index.stories.js
@@ -135,15 +135,6 @@ storiesOf('Dialog', module)
         <Input id="email" type="email" label="Email address" />
         <Input id="fname" label="First name" />
         <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
-        <Input id="lname" label="Last name" />
       </Box>
     </MyDialog>
   ))


### PR DESCRIPTION
When testing the latest changes to the Dialog component I noticed Firefox is treating `flex-shrink` differently than Chrome. This PR addresses the issue.