### PR TITLE
fix(Button): Set default hover text color for the Button component

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -89,6 +89,7 @@ const StyledButton = styled.button`
 
   &:hover,
   &:focus {
+    color: white;
     background-color: ${color.earthLight};
 
     ${props =>
@@ -104,7 +105,6 @@ const StyledButton = styled.button`
       props.variant === 'inverted' &&
       css`
         background-color: ${color.earth};
-        color: white;
       `};
 
     ${props =>


### PR DESCRIPTION
# Description

Changes the default hover text color of the Button component.
## Changes

- [x] Change default hover text color

## How to test

- Checkout this branch
- `$ npm run docs`
