### PR TITLE
fix(Input): Add display block to styled label

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -80,6 +80,7 @@ const Field = styled.input`
 
 const Label = styled.label`
   position: relative;
+  display: block;
 `
 
 const LabelText = styled.span`


### PR DESCRIPTION
With display block added to the styled label we make sure that the input takes up 100% width, like
intended.
