### PR TITLE
Update Rollup config and only export ES bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20195,18 +20195,6 @@
         "rollup-pluginutils": "^2.0.1"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
-      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
-        "terser": "^3.14.1"
-      }
-    },
     "rollup-plugin-visualizer": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-0.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -70,15 +70,15 @@
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-progress": "^1.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-visualizer": "^0.9.2",
     "rollup-watch": "^4.3.1",
     "semantic-release": "^15.13.3",
     "styled-components": "^4.1.3"
   },
-  "main": "dist/solar.js",
+  "main": "dist/solar.es.js",
+  "module": "dist/solar.es.js",
   "files": [
-    "dist"
+    "dist/*"
   ],
   "license": "MIT",
   "repository": "https://github.com/TicketSwap/solar"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,42 +5,13 @@ import progress from 'rollup-plugin-progress'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import replace from 'rollup-plugin-replace'
 import visualizer from 'rollup-plugin-visualizer'
-import { terser } from 'rollup-plugin-terser'
-
-const isProduction = process.env.NODE_ENV === 'production'
 
 export default {
   input: 'src/index.js',
   output: [
     {
-      file: 'dist/solar.js',
-      format: 'umd',
-      name: '@ticketswap/solar',
-      exports: 'named',
-      globals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
-        'prop-types': 'PropTypes',
-        'styled-components': 'styled',
-        'react-spring': 'ReactSpring',
-        downshift: 'Downshift',
-      },
-      sourcemap: isProduction ? false : 'inline',
-    },
-    {
       file: 'dist/solar.es.js',
       format: 'es',
-      name: '@ticketswap/solar',
-      exports: 'named',
-      globals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
-        'prop-types': 'PropTypes',
-        'styled-components': 'styled',
-        'react-spring': 'ReactSpring',
-        downshift: 'Downshift',
-      },
-      sourcemap: isProduction ? false : 'inline',
     },
   ],
   plugins: [
@@ -55,7 +26,6 @@ export default {
         process.env.NODE_ENV || 'development'
       ),
     }),
-    isProduction && terser(),
     visualizer(),
     filesize(),
   ],


### PR DESCRIPTION
This updates the Rollup config to only export a `ES` module bundle, no more `UMD` build.