### PR TITLE
Add back globals object in Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,16 @@ export default {
   output: [
     {
       file: 'dist/solar.es.js',
+      name: '@ticketswap/solar',
+      exports: 'named',
+      globals: {
+        react: 'React',
+        'react-dom': 'ReactDOM',
+        'prop-types': 'PropTypes',
+        'styled-components': 'styled',
+        'react-spring': 'ReactSpring',
+        downshift: 'Downshift',
+      },
       format: 'es',
     },
   ],


### PR DESCRIPTION
Previous update removed the globals object which broke imports.