### PR TITLE
Disable bundle minification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20195,18 +20195,6 @@
         "rollup-pluginutils": "^2.0.1"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
-      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
-        "terser": "^3.14.1"
-      }
-    },
     "rollup-plugin-visualizer": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-0.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-progress": "^1.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-visualizer": "^0.9.2",
     "rollup-watch": "^4.3.1",
     "semantic-release": "^15.13.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,19 +5,17 @@ import progress from 'rollup-plugin-progress'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import replace from 'rollup-plugin-replace'
 import visualizer from 'rollup-plugin-visualizer'
-import { terser } from 'rollup-plugin-terser'
-
-const isProduction = process.env.NODE_ENV === 'production'
+import pkg from './package.json'
 
 export default {
   input: 'src/index.js',
   output: [
     {
-      file: 'dist/solar.js',
+      file: pkg.main,
       format: 'cjs',
     },
     {
-      file: 'dist/solar.es.js',
+      file: pkg.module,
       format: 'esm',
     },
   ],
@@ -33,7 +31,6 @@ export default {
         process.env.NODE_ENV || 'development'
       ),
     }),
-    isProduction && terser(),
     visualizer(),
     filesize(),
   ],


### PR DESCRIPTION
Solar is meant to be consumed by other bundlers anyway and does not profit from minification (in
fact this will make it harder to hunt for bugs).