### PR TITLE
Refactor dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18988,15 +18988,15 @@
       }
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.1.tgz",
+      "integrity": "sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.1"
       }
     },
     "react-dev-utils": {
@@ -19184,15 +19184,15 @@
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
+      "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.1"
       }
     },
     "react-error-overlay": {
@@ -20593,9 +20593,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
+      "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "jest-watch-typeahead": "^0.2.1",
     "lint-staged": "^8.1.3",
     "prettier": "^1.16.4",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-measure": "^2.2.4",
     "react-spring": "^7.2.10",
     "react-testing-library": "^5.5.3",

--- a/src/components/Dialog/index.stories.js
+++ b/src/components/Dialog/index.stories.js
@@ -10,6 +10,7 @@ import {
   DialogAdornment,
   DialogBody,
   DialogFooter,
+  useDialog,
 } from './'
 import { color, easingFunctions } from '../../theme'
 import { Button } from '../Button'
@@ -40,7 +41,7 @@ const Login = props => (
   </DialogBody>
 )
 
-const LoginEmail = props => (
+const LoginEmail = () => (
   <DialogBody>
     <Box display="grid" gridGap={8} marginBottom={16}>
       <Input type="email" id="email" label="Email address" hideLabel />
@@ -68,7 +69,7 @@ const Signup = props => (
   </DialogBody>
 )
 
-const SignupEmail = props => (
+const SignupEmail = () => (
   <>
     <DialogBody>
       <Box display="grid" gridGap={8}>
@@ -115,6 +116,25 @@ const MyDialog = ({ children, ...props }) => (
     )}
   </Dialog>
 )
+
+function MyNewDialog() {
+  const { hide, getToggleProps, getWindowProps } = useDialog({
+    onToggle: val => console.log(val),
+  })
+
+  return (
+    <>
+      <Button {...getToggleProps()}>Show dialog</Button>
+      <DialogWindow {...getWindowProps()}>
+        <DialogHeader>Dialog Title</DialogHeader>
+        <DialogBody>Body</DialogBody>
+        <DialogFooter>
+          <Button onClick={hide}>Discard</Button>
+        </DialogFooter>
+      </DialogWindow>
+    </>
+  )
+}
 
 storiesOf('Dialog', module)
   .add('basic', () => <MyDialog>Body</MyDialog>)
@@ -237,3 +257,4 @@ storiesOf('Dialog', module)
       )}
     </Dialog>
   ))
+  .add('useDialog', () => <MyNewDialog />)

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { useLockBodyScroll } from './useLockBodyScroll'

--- a/src/hooks/useLockBodyScroll.js
+++ b/src/hooks/useLockBodyScroll.js
@@ -1,0 +1,225 @@
+import { useLayoutEffect } from 'react'
+
+// Adopted and modified implementation of `body-scroll-lock`
+// https://github.com/willmcpo/body-scroll-lock
+
+// Older browsers don't support event options, feature detect it.
+let hasPassiveEvents = false
+if (typeof window !== 'undefined') {
+  const passiveTestOptions = {
+    get passive() {
+      hasPassiveEvents = true
+      return undefined
+    },
+  }
+  window.addEventListener('testPassive', null, passiveTestOptions)
+  window.removeEventListener('testPassive', null, passiveTestOptions)
+}
+
+const isIosDevice =
+  typeof window !== 'undefined' &&
+  window.navigator &&
+  window.navigator.platform &&
+  /iP(ad|hone|od)/.test(window.navigator.platform)
+
+let locks = []
+let documentListenerAdded = false
+let initialClientY = -1
+let previousBodyOverflowSetting
+let previousBodyPaddingRight
+
+// returns true if `el` should be allowed to receive touchmove events
+const allowTouchMove = el =>
+  locks.some(lock => {
+    if (lock.options.allowTouchMove && lock.options.allowTouchMove(el)) {
+      return true
+    }
+
+    return false
+  })
+
+const preventDefault = rawEvent => {
+  const e = rawEvent || window.event
+
+  // For the case whereby consumers adds a touchmove event listener to document.
+  // Recall that we do document.addEventListener('touchmove', preventDefault, { passive: false })
+  // in disableBodyScroll - so if we provide this opportunity to allowTouchMove, then
+  // the touchmove event on document will break.
+  if (allowTouchMove(e.target)) {
+    return true
+  }
+
+  // Do not prevent if the event has more than one touch (usually meaning this is a multi touch gesture like pinch to zoom)
+  if (e.touches.length > 1) return true
+
+  if (e.preventDefault) e.preventDefault()
+
+  return false
+}
+
+const setOverflowHidden = options => {
+  // Setting overflow on body/documentElement synchronously in Desktop Safari slows down
+  // the responsiveness for some reason. Setting within a setTimeout fixes this.
+  setTimeout(() => {
+    // If previousBodyPaddingRight is already set, don't set it again.
+    if (previousBodyPaddingRight === undefined) {
+      const reserveScrollBarGap =
+        !!options && options.reserveScrollBarGap === true
+      const scrollBarGap =
+        window.innerWidth - document.documentElement.clientWidth
+
+      if (reserveScrollBarGap && scrollBarGap > 0) {
+        previousBodyPaddingRight = document.body.style.paddingRight
+        document.body.style.paddingRight = `${scrollBarGap}px`
+      }
+    }
+
+    // If previousBodyOverflowSetting is already set, don't set it again.
+    if (previousBodyOverflowSetting === undefined) {
+      previousBodyOverflowSetting = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+    }
+  })
+}
+
+const restoreOverflowSetting = () => {
+  // Setting overflow on body/documentElement synchronously in Desktop Safari slows down
+  // the responsiveness for some reason. Setting within a setTimeout fixes this.
+  setTimeout(() => {
+    if (previousBodyPaddingRight !== undefined) {
+      document.body.style.paddingRight = previousBodyPaddingRight
+
+      // Restore previousBodyPaddingRight to undefined so setOverflowHidden knows it
+      // can be set again.
+      previousBodyPaddingRight = undefined
+    }
+
+    if (previousBodyOverflowSetting !== undefined) {
+      document.body.style.overflow = previousBodyOverflowSetting
+
+      // Restore previousBodyOverflowSetting to undefined
+      // so setOverflowHidden knows it can be set again.
+      previousBodyOverflowSetting = undefined
+    }
+  })
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
+const isTargetElementTotallyScrolled = targetElement =>
+  targetElement
+    ? targetElement.scrollHeight - targetElement.scrollTop <=
+      targetElement.clientHeight
+    : false
+
+const handleScroll = (event, targetElement) => {
+  const clientY = event.targetTouches[0].clientY - initialClientY
+
+  if (allowTouchMove(event.target)) {
+    return false
+  }
+
+  if (targetElement && targetElement.scrollTop === 0 && clientY > 0) {
+    // element is at the top of its scroll
+    return preventDefault(event)
+  }
+
+  if (isTargetElementTotallyScrolled(targetElement) && clientY < 0) {
+    // element is at the top of its scroll
+    return preventDefault(event)
+  }
+
+  event.stopPropagation()
+  return true
+}
+
+export const disableBodyScroll = (targetElement, options) => {
+  if (isIosDevice) {
+    // targetElement must be provided, and disableBodyScroll must not have been
+    // called on this targetElement before.
+    if (!targetElement) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'disableBodyScroll unsuccessful - targetElement must be provided when calling disableBodyScroll on IOS devices.'
+      )
+      return
+    }
+
+    if (
+      targetElement &&
+      !locks.some(lock => lock.targetElement === targetElement)
+    ) {
+      const lock = {
+        targetElement,
+        options: options || {},
+      }
+
+      locks = [...locks, lock]
+
+      targetElement.ontouchstart = event => {
+        if (event.targetTouches.length === 1) {
+          // detect single touch
+          initialClientY = event.targetTouches[0].clientY
+        }
+      }
+      targetElement.ontouchmove = event => {
+        if (event.targetTouches.length === 1) {
+          // detect single touch
+          handleScroll(event, targetElement)
+        }
+      }
+
+      if (!documentListenerAdded) {
+        document.addEventListener(
+          'touchmove',
+          preventDefault,
+          hasPassiveEvents ? { passive: false } : undefined
+        )
+        documentListenerAdded = true
+      }
+    }
+  } else {
+    setOverflowHidden(options)
+    const lock = {
+      targetElement,
+      options: options || {},
+    }
+
+    locks = [...locks, lock]
+  }
+}
+
+export const clearAllBodyScrollLocks = () => {
+  if (isIosDevice) {
+    // Clear all locks ontouchstart/ontouchmove handlers, and the references
+    locks.forEach(lock => {
+      lock.targetElement.ontouchstart = null
+      lock.targetElement.ontouchmove = null
+    })
+
+    if (documentListenerAdded) {
+      document.removeEventListener(
+        'touchmove',
+        preventDefault,
+        hasPassiveEvents ? { passive: false } : undefined
+      )
+      documentListenerAdded = false
+    }
+
+    locks = []
+
+    // Reset initial clientY
+    initialClientY = -1
+  } else {
+    restoreOverflowSetting()
+    locks = []
+  }
+}
+
+export function useLockBodyScroll(targetRef) {
+  useLayoutEffect(() => {
+    disableBodyScroll(targetRef.current, {
+      reserveScrollBarGap: true,
+    })
+    return () => clearAllBodyScrollLocks()
+  }, [])
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export * from './theme'
+export * from './hooks'
 export { Alert } from './components/Alert'
 export { Avatar } from './components/Avatar'
 export { Banner } from './components/Banner'
@@ -24,6 +25,7 @@ export {
   DialogAdornment,
   DialogBody,
   DialogFooter,
+  useDialog,
 } from './components/Dialog'
 export { Flag } from './components/Flag'
 export { globalStyles } from './global-styles'


### PR DESCRIPTION
# Description

This adds support for an optional prop `lockBodyScroll` that if `true` applies `overflow: hidden;` on the `<body>`. Also added a new export `useDialog()` – see the newly added story for how to use it.