### PR TITLE
Change async arrow fn to avoid bug in Safari

### DIFF
--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -34,6 +34,11 @@ const StyledImage = styled.img`
 `
 
 export class Image extends Component {
+  constructor(props) {
+    super(props)
+    this.handleLoad = this.handleLoad.bind(this)
+  }
+
   observer = null
   initialState = {
     loaded: false,
@@ -60,10 +65,10 @@ export class Image extends Component {
     return `data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}"%3E%3C/svg%3E`
   }
 
-  handleLoad = async () => {
+  async handleLoad() {
     const { src } = this.props
     await fetchImage(src)
-    this.setState({ loaded: true, src })
+    return this.setState({ loaded: true, src })
   }
 
   handleLazyLoad = entries => {


### PR DESCRIPTION
Safari has a bug that’ll throw an error if it encounters async arrow function. This PR addresses the issue.

https://github.com/babel/babel/issues/9465
https://github.com/mobxjs/mobx/issues/1169#issuecomment-330060296
https://bugs.webkit.org/show_bug.cgi?id=166879