### PR TITLE
Correctly pass variant to `Alert` adornment

### DIFF
--- a/src/components/Alert/index.js
+++ b/src/components/Alert/index.js
@@ -95,7 +95,7 @@ const SecondaryActionAdornment = styled.span`
 export const Alert = props => {
   return (
     <Container {...props}>
-      <Adornment>
+      <Adornment variant={props.variant}>
         <Icon
           glyph={
             props.variant === 'success'


### PR DESCRIPTION
# Description

Adornment was missing the `variant` prop.

## How to test

- Checkout this branch
- `$ npm run storybook`