### PR TITLE
Avatar: Fix overflow issue in Safari

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -14,6 +14,8 @@ const Wrapper = styled.div`
   border-radius: 100%;
   position: relative;
   overflow: hidden;
+  backface-visibility: hidden;
+  transform: translate3d(0, 0, 0);
 `
 
 const imageStyles = css`


### PR DESCRIPTION
Safari doesn’t respect the overflow attribute when an element is transformed. This PR addresses the issue.

## Screenshots

![avatar](https://user-images.githubusercontent.com/491962/54770813-456f1a00-4c04-11e9-943e-c31c323e486e.gif)