### PR TITLE
Downgrade `babel-eslint`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4113,9 +4113,9 @@
       "dev": true
     },
     "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@storybook/react": "^5.0.6",
     "@storybook/storybook-deployer": "^2.8.1",
     "babel-core": "^7.0.0-bridge.0",
-    "babel-eslint": "^10.0.1",
+    "babel-eslint": "9.0.0",
     "babel-plugin-styled-components": "^1.10.0",
     "commitizen": "^3.0.7",
     "cz-conventional-changelog": "^2.1.0",


### PR DESCRIPTION
Updated this one accidentally. `eslint-config-react-app` depends on `babel-eslint@9.x`.