### PR TITLE
fix(Button): Don't allow button to be clicked when loading

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -297,15 +297,19 @@ const Adornment = styled.span`
     `};
 `
 
-export const Button = ({ children, ...props }) => (
-  <StyledButton {...props}>
-    {props.loading || props.icon ? (
+export const Button = ({ children, onClick, loading, ...props }) => (
+  <StyledButton
+    onClick={loading ? () => null : onClick}
+    loading={loading}
+    {...props}
+  >
+    {loading || props.icon ? (
       <Adornment position={props.width === 'full' ? 'absolute' : null}>
-        {props.loading ? (
+        {loading ? (
           <Spinner size={24} />
-        ) : props.icon ? (
+        ) : (
           <Icon glyph={props.icon} size={24} />
-        ) : null}
+        )}
       </Adornment>
     ) : null}
     {children}


### PR DESCRIPTION
# What it should do
When clicking on a button that was in a loading state, the click handler would still be fired. This could lead to unwanted requests and states.

## What has been done and why?
- [x] Prevent click when loading
- [x] Change cursor when loading

## How should this be manually tested?
- Rebuild notebook
- Check buttons (loading)
