### PR TITLE
Replace `css`-prop usage with inline-styles

### DIFF
--- a/src/components/Dialog/index.stories.js
+++ b/src/components/Dialog/index.stories.js
@@ -25,13 +25,7 @@ const ViewContainer = styled.div`
 
 const Login = props => (
   <DialogBody>
-    <div
-      css={`
-        display: grid;
-        grid-gap: 0.5rem;
-        margin-bottom: 2rem;
-      `}
-    >
+    <div style={{ display: 'grid', gridGap: '0.5rem', marginBottom: '2rem' }}>
       <Button variant="facebook">Log in with Facebook</Button>
       <Button variant="secondary" onClick={() => props.select(2)}>
         Log in with email
@@ -48,11 +42,7 @@ const Login = props => (
 
 const LoginEmail = () => (
   <DialogBody>
-    <div
-      css={`
-        margin-bottom: 1rem;
-      `}
-    >
+    <div style={{ marginBottom: '1rem' }}>
       <Input type="email" id="email" label="Email address" hideLabel />
     </div>
     <Button variant="success" width="full">
@@ -63,13 +53,7 @@ const LoginEmail = () => (
 
 const Signup = props => (
   <DialogBody>
-    <div
-      css={`
-        display: grid;
-        grid-gap: 0.5rem;
-        margin-bottom: 2rem;
-      `}
-    >
+    <div style={{ display: 'grid', gridGap: '0.5rem', marginBottom: '2rem' }}>
       <Button variant="facebook">Sign up with Facebook</Button>
       <Button variant="secondary" onClick={() => props.select(3)}>
         Sign up with email

--- a/src/components/Image/index.stories.js
+++ b/src/components/Image/index.stories.js
@@ -29,13 +29,7 @@ storiesOf('Image', module)
     />
   ))
   .add('lazyload', () => (
-    <div
-      css={`
-        display: grid;
-        grid-gap: 2rem;
-        padding: 4rem;
-      `}
-    >
+    <div style={{ display: 'grid', gridGap: '2rem', padding: '4rem' }}>
       <Image
         src="https://images.unsplash.com/photo-1539550298564-8a06769aa728?auto=format&fit=crop&w=1200&q=80"
         width={300}

--- a/src/components/MenuButton/index.stories.js
+++ b/src/components/MenuButton/index.stories.js
@@ -10,11 +10,7 @@ const items = [
 
 storiesOf('MenuButton', module)
   .add('default', () => (
-    <div
-      css={`
-        padding: 2rem;
-      `}
-    >
+    <div style={{ padding: '2rem' }}>
       <span>
         Language:{' '}
         <MenuButton items={items} onChange={item => console.log(item)} />
@@ -23,12 +19,12 @@ storiesOf('MenuButton', module)
   ))
   .add('top', () => (
     <div
-      css={`
-        display: flex;
-        align-items: flex-end;
-        padding: 2rem;
-        height: 100vh;
-      `}
+      style={{
+        display: 'flex',
+        alignItems: 'flex-end',
+        padding: '2rem',
+        height: '100vh',
+      }}
     >
       <span>
         Language:{' '}

--- a/src/components/Toast/index.stories.js
+++ b/src/components/Toast/index.stories.js
@@ -24,12 +24,12 @@ storiesOf('Toasts', module)
             add(
               <Toast persist>
                 <div
-                  css={`
-                    display: flex;
-                    flex-direction: row;
-                    align-items: center;
-                    justify-content: space-between;
-                  `}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
                 >
                   <span>Payment failed</span>
                   <Button onClick={remove} size="small" variant="inverted">


### PR DESCRIPTION
`css`-prop usage would sometimes throw errors in Storybook. Since we haven’t been using it a lot, this just replaces all instances with inline styles.