### PR TITLE
Add helper text and input props

### DIFF
--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -120,10 +120,9 @@ export function DateInput({ id, label, hideLabel, ...props }) {
         <InputGroup>
           <InputWrapper>
             <Input
+              {...props.dayInputProps}
               id="day"
-              label="Day"
               hideLabel
-              placeholder="Day"
               value={day.toString()}
               onChange={e => setDay(e.target.value)}
             />
@@ -140,10 +139,9 @@ export function DateInput({ id, label, hideLabel, ...props }) {
           </SelectWrapper>
           <InputWrapper>
             <Input
+              {...props.yearInputProps}
               id="year"
-              label="Year"
               hideLabel
-              placeholder="Year"
               value={year.toString()}
               onChange={e =>
                 e.target.value.length < 5 && setYear(e.target.value)
@@ -158,12 +156,22 @@ export function DateInput({ id, label, hideLabel, ...props }) {
 
 DateInput.defaultProps = {
   onChange: () => {},
+  dayInputProps: {
+    label: 'Day',
+    placeholder: 'Day',
+  },
+  yearInputProps: {
+    label: 'Year',
+    placeholder: 'Year',
+  },
 }
 
 DateInput.propTypes = {
   onChange: PropTypes.func,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  dayInputProps: PropTypes.object,
+  yearInputProps: PropTypes.object,
   months: PropTypes.arrayOf(PropTypes.string).isRequired,
   initialSelectedDate: PropTypes.oneOfType([
     PropTypes.object,

--- a/src/components/DateInput/index.stories.js
+++ b/src/components/DateInput/index.stories.js
@@ -24,6 +24,12 @@ storiesOf('DateInput', module)
       label="Date of birth"
       months={months}
       onChange={date => console.log(date)}
+      dayInputProps={{
+        placeholder: 'Tag',
+      }}
+      yearInputProps={{
+        placeholder: 'Jahr',
+      }}
     />
   ))
   .add('with initial date (string)', () => (

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -12,6 +12,7 @@ import {
   fontSize,
   lineHeight,
   radius,
+  device,
 } from '../../theme'
 
 const InputWrapper = styled.div`
@@ -41,6 +42,7 @@ const Field = styled.input`
       : space[16]};
   color: ${props => (props.invalid ? color.mars : color.space)};
   box-shadow: none;
+  border: 0;
   text-align: left;
   appearance: none;
   transition: box-shadow ${transition}, background-color ${transition};
@@ -129,6 +131,17 @@ const ResetButton = styled.button`
   }
 `
 
+const Help = styled.p`
+  font-size: ${fontSize[14]};
+  margin-bottom: 0;
+  margin-top: ${space[6]};
+  color: ${color.spaceLight};
+
+  @media ${device.tablet} {
+    font-size: ${fontSize[16]};
+  }
+`
+
 export const Input = React.forwardRef(
   ({ id, label, hideLabel, labelProps, ...props }, ref) => (
     <Label htmlFor={!labelProps && id} {...labelProps}>
@@ -162,6 +175,7 @@ export const Input = React.forwardRef(
           <Adornment right>{props.rightAdornment}</Adornment>
         ) : null}
       </InputWrapper>
+      {props.help && <Help>{props.help}</Help>}
     </Label>
   )
 )

--- a/src/components/Input/index.stories.js
+++ b/src/components/Input/index.stories.js
@@ -8,6 +8,9 @@ storiesOf('Input', module)
   .add('with hidden label', () => (
     <Input id="fname" label="First name" hideLabel />
   ))
+  .add('with helper text', () => (
+    <Input id="fname" label="First name" help="Lorem ipsum dolor sit amet" />
+  ))
   .add('loading', () => (
     <Input
       placeholder="Search our docs"

--- a/src/theme.js
+++ b/src/theme.js
@@ -75,6 +75,7 @@ export const shadow = {
 export const space = {
   0: '0',
   4: '0.25rem',
+  6: '0.375rem',
   8: '0.5rem',
   12: '0.75rem',
   14: '0.875rem',


### PR DESCRIPTION
This adds optional helper texts to `<Input />` components and allows to pass props for the day and year fields of the `<DateInput />` component (e.g. to localise the placeholder texts).