### PR TITLE
refactor(Dialog): Update overflow-behaviour

### DIFF
--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -28,9 +28,13 @@ const DialogOverlay = styled.div`
   align-items: flex-end;
 
   @media ${device.mobileL} {
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     align-items: flex-start;
     padding-top: ${space[64]};
     padding-top: 10vmin;
+    padding-bottom: ${space[64]};
+    padding-bottom: 10vmin;
   }
 `
 
@@ -44,6 +48,7 @@ const DialogContent = styled.div`
   @media ${device.mobileL} {
     width: ${sizes.mobileL / 16}em;
     border-radius: ${radius.lg};
+    overflow: unset;
   }
 `
 
@@ -82,6 +87,7 @@ const BodyWrapper = styled.div`
 
   @media ${device.mobileL} {
     border-radius: ${radius.lg};
+    overflow: unset;
   }
 
   &::before,
@@ -94,8 +100,8 @@ const BodyWrapper = styled.div`
     right: 0;
     height: ${space[16]};
 
-    @media ${device.tablet} {
-      height: ${space[32]};
+    @media ${device.mobileL} {
+      display: none;
     }
   }
 
@@ -119,7 +125,7 @@ const BodyWrapper = styled.div`
 `
 
 const Body = styled.div`
-  max-height: 65vh;
+  max-height: 50vh;
   padding: ${space[16]};
   padding-bottom: calc(${space[16]} + env(safe-area-inset-bottom));
   overflow-y: scroll;
@@ -129,13 +135,15 @@ const Body = styled.div`
     display: none;
   }
 
-  @media ${device.mobileL} {
-    padding: ${space[32]};
-    max-height: calc(80vh - ${144 / 16}rem);
+  @media (min-height: 32em) {
+    max-height: 65vh;
   }
 
-  @media (min-height: ${sizes.tablet}) and (min-width: ${sizes.tablet}) {
-    max-height: calc(65vh - ${144 / 16}rem);
+  @media ${device.mobileL} {
+    padding: ${space[32]};
+    max-height: none;
+    overflow-y: unset;
+    -webkit-overflow-scrolling: auto;
   }
 `
 

--- a/src/components/Dialog/index.stories.js
+++ b/src/components/Dialog/index.stories.js
@@ -9,9 +9,20 @@ import {
   DialogFooter,
   useDialog,
 } from './'
+import { Select } from '../Select'
 import { Button } from '../Button'
 import { Input } from '../Input'
 import { Icon } from '../Icon'
+
+const items = [
+  { value: 'de', name: 'German' },
+  { value: 'it', name: 'Italian' },
+  { value: 'nl', name: 'Dutch' },
+  { value: 'en', name: 'English' },
+  { value: 'hu', name: 'Hungarian' },
+  { value: 'fr', name: 'French' },
+  { value: 'es', name: 'Spanish' },
+]
 
 const MyDialog = ({ children, ...props }) => (
   <Dialog {...props}>
@@ -30,6 +41,19 @@ const MyDialog = ({ children, ...props }) => (
             )}
           </DialogHeader>
           <DialogBody>{children}</DialogBody>
+          <DialogFooter>
+            <Button onClick={() => console.log('clicked')} width="full">
+              Save changes
+            </Button>
+            <Button
+              onClick={hide}
+              variant="caution"
+              width="full"
+              style={{ marginTop: 8 }}
+            >
+              Cancel
+            </Button>
+          </DialogFooter>
         </DialogWindow>
       </>
     )}
@@ -66,11 +90,18 @@ storiesOf('Dialog', module)
   ))
   .add('with long body', () => (
     <MyDialog>
-      <div>
+      <div style={{ display: 'grid', gridGap: 16 }}>
         <Input id="email" type="email" label="Email address" />
         <Input id="fname" label="First name" />
         <Input id="lname" label="Last name" />
         <Input id="message" label="Message" as="textarea" rows="4" />
+        <Select
+          items={items}
+          id="language"
+          label="Language"
+          onChange={selection => console.log(selection)}
+          initialSelectedItem={items[1]}
+        />
       </div>
     </MyDialog>
   ))


### PR DESCRIPTION
This is updating the overflow-behaviour for dialogs on desktop viewports. Dialogs with over-sized contents will now scroll inside the semi-transparent backdrop, instead of in itself. The mobile behaviour remains the same.