### PR TITLE
Add semantic pull request config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate all commits, and ignore the PR title
+commitsOnly: true


### PR DESCRIPTION
# Description

Let's make sure that we don't merge PR's without `semantic-release` and `conventional commit` messages by adding https://github.com/probot/semantic-pull-requests to solar

This PR contains the configuration to overwrite the defaults. PRs that contains commits without the conventional commit standard will not pass the check.

![image](https://user-images.githubusercontent.com/968014/57729712-25edee00-7697-11e9-9950-73fdaf29430b.png)


