### PR TITLE
Remove express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "express": "^4.16.4",
     "husky": "^2.2.0",
     "is-ci-cli": "^1.1.1",
     "jest": "^24.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5562,7 +5562,7 @@ expect@^24.7.1:
     jest-message-util "^24.7.1"
     jest-regex-util "^24.3.0"
 
-express@^4.16.3, express@^4.16.4:
+express@^4.16.3:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
   integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==


### PR DESCRIPTION
Not sure why we had `express` in there?