### PR TITLE
fix(DateInput): Only allow numbers for day and year inputs

### DIFF
--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -131,7 +131,7 @@ export function DateInput({ id, label, hideLabel, onChange, ...props }) {
               id="day"
               hideLabel
               value={day ? parseInt(day).toString() : ''}
-              onChange={e => setDay(e.target.value)}
+              onChange={e => setDay(parseInt(e.target.value) || '')}
             />
           </InputWrapper>
           <SelectWrapper>
@@ -151,7 +151,8 @@ export function DateInput({ id, label, hideLabel, onChange, ...props }) {
               hideLabel
               value={year.toString()}
               onChange={e =>
-                e.target.value.length < 5 && setYear(e.target.value)
+                e.target.value.length < 5 &&
+                setYear(parseInt(e.target.value) || '')
               }
             />
           </InputWrapper>


### PR DESCRIPTION
# Description
This will make sure you can only fill in numbers for the day and year input.

## Changes

- [x] Fix day and year input

## How to test
- `yarn; yarn dev`
- Check date input field
- See you can't fill in chars
