### PR TITLE
fix(InputMenuList): Overflow

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -171,7 +171,7 @@ export const InputMenuFooter = styled.footer`
 export const InputMenuList = styled.ul`
   max-height: ${space[256]};
   margin: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding: 0;
 `


### PR DESCRIPTION
# Description

Right now the overflow property of the InputMenuList (part of the Input component) has a value of `scroll`. Because of this, windows users (and people who always enabled scroll bars on mac) will see the background of the scrollbar if if the list only contains one item. By using the value `auto` we can prevent this, and if the list get's longer, it will show the scroll bar again.

Not sure if this is the right approach but I created the PR for discussion.

## Changes

- [x] Change overlfow property on InputMenuList

## Screenshots

Before
<img width="471" alt="Schermafbeelding 2019-07-05 om 11 50 11" src="https://user-images.githubusercontent.com/14276144/60714809-0bf4bd00-9f1c-11e9-9c14-e95605d45f24.png">

After
<img width="460" alt="Schermafbeelding 2019-07-05 om 11 49 50" src="https://user-images.githubusercontent.com/14276144/60714853-1fa02380-9f1c-11e9-9c1c-f71e80b0b718.png">



