### PR TITLE
fix(MoneyInput): Parse initial amount with at least 2 decimals

### DIFF
--- a/src/components/MoneyInput/index.js
+++ b/src/components/MoneyInput/index.js
@@ -69,11 +69,16 @@ export function MoneyInput({
     isCurrencyControlled || props.initialSelectedCurrency
       ? currencies.indexOf(props.currency || props.initialSelectedCurrency)
       : 0
+  const initialValue = props.initialAmount ? props.initialAmount / 100 : 0
+  const [amount, setAmount] = React.useState(
+    props.initialAmount
+      ? Number.isInteger(initialValue)
+        ? initialValue
+        : initialValue.toFixed(2)
+      : ''
+  )
   const [currency, setCurrency] = React.useState(
     currencies[intialSelectedIndex]
-  )
-  const [amount, setAmount] = React.useState(
-    props.initialAmount ? props.initialAmount / 100 : ''
   )
   const options = createSelectOptions(currencies)
   const inputRef = React.useRef()

--- a/src/components/MoneyInput/index.stories.js
+++ b/src/components/MoneyInput/index.stories.js
@@ -134,7 +134,7 @@ storiesOf('MoneyInput', module)
       currencies={currencies}
       onChange={e => console.log(e)}
       initialSelectedCurrency={currencies[2]}
-      initialAmount={2500}
+      initialAmount={240050}
       help="Leave blank for no maximum price"
     />
   ))


### PR DESCRIPTION
# Description

This will fix an issue we have with the money input, where amounts like 1650 (16,50) will result in 16,5.

## Changes

- [x] Parse amount with fixed decimals of 2 if it's a float.

## How to test

- Checkout this branch
- Checkout the MoneyInput component with the Initial amount

## Screenshots
It will fix this problem:

<img width="1098" alt="Schermafbeelding 2019-07-29 om 15 11 17" src="https://user-images.githubusercontent.com/14276144/62051214-33852f80-b213-11e9-834c-dbcea2936d78.png">


