### PR TITLE
feat(useTransition): change return value

### DIFF
--- a/src/components/ContentTransition/index.js
+++ b/src/components/ContentTransition/index.js
@@ -34,7 +34,7 @@ const SlideContainer = styled.div`
 `
 
 function Slide({ active, children, setTransitioning, ...props }) {
-  const { state, show, transitioning } = useTransition({ on: active, duration })
+  const [state, show, transitioning] = useTransition({ on: active, duration })
 
   React.useEffect(() => {
     setTransitioning(transitioning)

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -28,7 +28,7 @@ const DialogOverlay = styled.div`
   justify-content: center;
   align-items: flex-end;
   opacity: ${props =>
-    props.state === 'mounting' || props.state === 'mounted' ? 1 : 0};
+    props.status === 'mounting' || props.status === 'mounted' ? 1 : 0};
   transition: opacity ${duration}ms ${easing.easeOutCubic};
 
   @media ${device.mobileL} {
@@ -49,7 +49,7 @@ const Content = styled.div`
   border-radius: ${radius.lg} ${radius.lg} 0 0;
   overflow: hidden;
   transform: ${props =>
-    props.state === 'mounting' || props.state === 'mounted'
+    props.status === 'mounting' || props.status === 'mounted'
       ? 'translate3d(0,0,0)'
       : 'translate3d(0,1rem,0)'};
   transition: transform ${duration}ms ${easing.easeOutCubic};
@@ -59,7 +59,7 @@ const Content = styled.div`
     border-radius: ${radius.lg};
     overflow: unset;
     transform: ${props => {
-      switch (props.state) {
+      switch (props.status) {
         case 'unmounted':
           return 'translate3d(0,-1rem,0)'
         case 'unmounting':
@@ -269,7 +269,7 @@ export function useDialog(config = {}) {
 }
 
 export function DialogWindow({ children, on, hide, ...props }) {
-  const { state, show } = useTransition({ on, duration })
+  const [status, mounted] = useTransition({ on, duration })
   const handleHide = React.useCallback(
     ({ keyCode }) => keyCode === 27 && hide(),
     [hide]
@@ -289,18 +289,18 @@ export function DialogWindow({ children, on, hide, ...props }) {
 
   return (
     <Portal>
-      {show && (
+      {mounted && (
         <DialogOverlay
           aria-modal="true"
           tabIndex="-1"
-          state={state}
+          status={status}
           data-testid="dialog-overlay"
           {...props}
         >
           <DialogContent
             onClick={stopPropagation}
             data-testid="dialog-content"
-            state={state}
+            status={status}
           >
             {children}
           </DialogContent>

--- a/src/components/MenuButton/index.js
+++ b/src/components/MenuButton/index.js
@@ -34,11 +34,11 @@ const MenuContainer = styled.div`
   left: 50%;
   bottom: 0;
   opacity: ${props =>
-    props.state === 'mounting' || props.state === 'mounted' ? 1 : 0};
+    props.status === 'mounting' || props.status === 'mounted' ? 1 : 0};
   transform: ${props =>
-    props.state === 'mounting' ||
-    props.state === 'mounted' ||
-    props.state === 'unmounting'
+    props.status === 'mounting' ||
+    props.status === 'mounted' ||
+    props.status === 'unmounting'
       ? 'translate3d(-50%,0,0)'
       : `translate3d(-50%,${props.dropdownPosition === 'top' ? -1 : 1}rem,0)`};
   transition: opacity ${duration}ms ease-out, transform ${duration}ms ease-out;
@@ -63,7 +63,7 @@ export function MenuButton({
   const ref = useRef()
   useOnClickOutside(ref, () => setIsOpen(false))
   const esc = useKeyPress('Escape')
-  const { state, show } = useTransition({ on: isOpen, duration })
+  const [status, mounted] = useTransition({ on: isOpen, duration })
 
   useEffect(() => {
     // Close menu with Esc key
@@ -86,9 +86,9 @@ export function MenuButton({
         {selectedItem.name} <span aria-hidden>▾</span>
       </Button>
 
-      {show && (
+      {mounted && (
         <MenuContainer
-          state={state}
+          status={status}
           ref={ref}
           dropdownPosition={dropdownPosition}
         >

--- a/test/setup-tests.js
+++ b/test/setup-tests.js
@@ -1,10 +1,12 @@
 // Mock custom useTransition hook
 jest.mock('../src/hooks/useTransition', () => {
   return {
-    useTransition: ({ on }) => ({
-      state: on ? 'mounted' : 'unmounted',
-      show: on,
-    }),
+    useTransition: ({ on }) => {
+      const status = on ? 'mounted' : 'unmounted'
+      const mounted = on
+      const transitioning = false
+      return [status, mounted, transitioning]
+    },
   }
 })
 


### PR DESCRIPTION
The `useTransition` hook will now return an array instead of an object to improve handling of multiple hook calls in one place.