### PR TITLE
Allow click and key-handlers for on-controlled dialogs

### DIFF
--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -220,7 +220,6 @@ export function useDialog(config = {}) {
   const isOnControlled = React.useCallback(() => {
     return props.on !== undefined
   }, [props.on])
-
   const [on, setOn] = useState(isOnControlled() ? props.on : false)
   const previousOn = usePrevious(isOnControlled() ? props.on : on)
   const show = () => !isOnControlled() && setOn(true)
@@ -268,11 +267,16 @@ export function useDialog(config = {}) {
   }
 }
 
-export function DialogWindow({ children, on, hide, ...props }) {
+export function DialogWindow({ children, on, hide, onEscKeyDown, ...props }) {
   const [state, mounted] = useTransition({ in: on, timeout: duration })
   const handleHide = React.useCallback(
-    ({ keyCode }) => keyCode === 27 && hide(),
-    [hide]
+    ({ keyCode }) => {
+      if (keyCode === 27) {
+        onEscKeyDown && onEscKeyDown()
+        hide()
+      }
+    },
+    [onEscKeyDown, hide]
   )
 
   useEffect(() => {

--- a/src/components/Dialog/index.stories.js
+++ b/src/components/Dialog/index.stories.js
@@ -36,7 +36,12 @@ function ControlledDialog() {
       </Button>
       <Dialog on={show} onToggle={console.log}>
         {({ getWindowProps }) => (
-          <DialogWindow {...getWindowProps()}>
+          <DialogWindow
+            {...getWindowProps({
+              onClick: () => show && setShow(false),
+              onEscKeyDown: () => show && setShow(false),
+            })}
+          >
             <DialogHeader>Hi</DialogHeader>
             <DialogBody>I am a controlled dialog</DialogBody>
           </DialogWindow>


### PR DESCRIPTION
# Description

This allows on-controlled dialogs to be closed with the `Esc`-key and via overlay-click.