### PR TITLE
Add onReset prop for uncontrolled Input components

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -212,6 +212,9 @@ export const Input = React.forwardRef(
         : typeof validate === 'function'
         ? !validate(props.value)
         : !validate
+    const showResetButton =
+      (props.value && props.value.length && props.onReset) ||
+      (!props.value && ref && props.onReset)
 
     return (
       <Label htmlFor={!labelProps && id} {...labelProps}>
@@ -237,7 +240,7 @@ export const Input = React.forwardRef(
             <Adornment right>
               <Spinner size={24} />
             </Adornment>
-          ) : props.value && props.value.length && props.onReset ? (
+          ) : showResetButton ? (
             <Adornment right>
               <ResetButton
                 onClick={props.onReset}

--- a/src/components/Input/index.stories.js
+++ b/src/components/Input/index.stories.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useState } from 'react'
 import { Input } from './'
 import { MagnifyingGlass } from '@ticketswap/comets'
 
@@ -97,6 +97,31 @@ export const WithClearButton = () => (
 
 WithClearButton.story = {
   name: 'With clear button',
+}
+
+export const UncontrolledInput = () => {
+  const [query, setQuery] = useState('')
+  const inputRef = useRef()
+
+  function handleReset() {
+    setQuery('')
+    inputRef.current.value = ''
+  }
+
+  return (
+    <Input
+      type="search"
+      ref={inputRef}
+      id="id"
+      label="Label"
+      onChange={event => setQuery(event.target.value)}
+      {...(query.length > 0 && { onReset: handleReset })}
+    />
+  )
+}
+
+UncontrolledInput.story = {
+  name: 'Uncontrolled input',
 }
 
 export const WithCustomLabelProps = () => (


### PR DESCRIPTION
# Description

Rarely we want to use the Input component as a uncontrolled input. Because this is based on a `ref`, and not value, the `onReset` prop wouldn't work. This PR tries to fix that.

As far as I know a ref isn't reactive so I came up with the solution to always show the clear icon if there is a `onReset` and `ref` prop passed, and then you can conditionally spread the onReset in the parent component. See the added story for more context. 

## Changes

- [x] Changes to onReset
- [x] Added story in storyboard

## How to test

- Checkout this branch
- `$ yarn dev`