### PR TITLE
Remove overflow hidden from panel component

### DIFF
--- a/src/components/Panel/index.js
+++ b/src/components/Panel/index.js
@@ -11,7 +11,6 @@ import {
 
 export const Panel = styled.div`
   ${fullBleed};
-  overflow: hidden;
   background-color: white;
   box-shadow: ${shadow.strong};
 
@@ -27,6 +26,16 @@ export const PanelContent = styled.div`
   flex-direction: row;
   justify-content: space-between;
   background-color: ${p => (p.bgColor ? p.bgColor : 'white')};
+
+  &:first-of-type {
+    border-top-left-radius: ${radius.lg};
+    border-top-right-radius: ${radius.lg};
+  }
+
+  &:last-of-type {
+    border-bottom-left-radius: ${radius.lg};
+    border-bottom-right-radius: ${radius.lg};
+  }
 
   & + ${() => PanelContent} {
     border-top: 1px solid ${color.spaceLightest};

--- a/src/components/Panel/index.stories.js
+++ b/src/components/Panel/index.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { H4 } from '../Heading'
 import { BaseButton } from '../BaseButton'
 import { Toggle } from '../Toggle'
+import { color } from '../../theme'
 import { Panel, PanelContent, PanelText, PanelBody, PanelFooter } from './'
 
 const Wrapper = story => <div style={{ padding: 24 }}>{story()}</div>
@@ -26,6 +27,31 @@ export const Single = () => (
 export const Group = () => (
   <Panel>
     <PanelContent>
+      <PanelBody>
+        <H4>Title</H4>
+        <PanelText>Lorem ipsum dolor sit amet</PanelText>
+        <BaseButton>Edit</BaseButton>
+      </PanelBody>
+      <PanelFooter>
+        <Toggle />
+      </PanelFooter>
+    </PanelContent>
+    <PanelContent>
+      <PanelBody>
+        <H4>Title</H4>
+        <PanelText>Lorem ipsum dolor sit amet</PanelText>
+        <BaseButton>Edit</BaseButton>
+      </PanelBody>
+      <PanelFooter>
+        <Toggle />
+      </PanelFooter>
+    </PanelContent>
+  </Panel>
+)
+
+export const WithSelected = () => (
+  <Panel>
+    <PanelContent bgColor={color.earthLightest}>
       <PanelBody>
         <H4>Title</H4>
         <PanelText>Lorem ipsum dolor sit amet</PanelText>


### PR DESCRIPTION
# Description
While working on the panel component is Sirius, I came across some strange behaviour. If you look at this screenshot it makes it clear why the overflow hidden isn't the best solution:
![image](https://user-images.githubusercontent.com/22071649/69805617-4f103f00-11e1-11ea-9b33-7c06a03b4e5d.png)


## Changes

- [x] Changed overflow hidden for border-radius.
- [x] Added selected state to storybook

## Screenshots
![image](https://user-images.githubusercontent.com/22071649/69805677-6cdda400-11e1-11ea-8cff-dc045215c496.png)