### PR TITLE
fix(DateInput): Make it possible to use placeholders for DateInput

### DIFF
--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -70,10 +70,9 @@ function splitDateString(str) {
   return str.split('-')
 }
 
-function getDate(input) {
+function getDate(input, months) {
   if (!input) {
-    const now = new Date()
-    return [now.getFullYear(), now.getMonth(), now.getDate()]
+    return [null, months[0], null]
   }
   if (typeof input === 'string') {
     const [year, month, day] = input.split(/[^0-9]/)
@@ -89,7 +88,8 @@ export function DateInput({ id, label, hideLabel, onChange, ...props }) {
   const dateInputRef = React.useRef()
   const months = createSelectOptions(props.months)
   const [initialYear, initialMonth, initialDay] = getDate(
-    props.initialSelectedDate
+    props.initialSelectedDate,
+    months
   )
   const [year, setYear] = React.useState(initialYear || '')
   const [month, setMonth] = React.useState(initialMonth || 0)


### PR DESCRIPTION
# Description

Instead of the init value of the date today we just want to show the placeholders.

## Changes

- [x] Removed prefix of the date when you don't pass init value

## How to test

- Checkout this branch
- `$ yarn dev`
- Checkout the first story

<img width="1723" alt="Schermafbeelding 2019-12-04 om 16 03 08" src="https://user-images.githubusercontent.com/14276144/70153662-9b5ef180-16af-11ea-8cc0-c2434c8e61ba.png">
