### PR TITLE
DateInput > use null instead of first index of array for months value

### DIFF
--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -70,9 +70,9 @@ function splitDateString(str) {
   return str.split('-')
 }
 
-function getDate(input, months) {
+function getDate(input) {
   if (!input) {
-    return [null, months[0], null]
+    return [null, null, null]
   }
   if (typeof input === 'string') {
     const [year, month, day] = input.split(/[^0-9]/)
@@ -88,8 +88,7 @@ export function DateInput({ id, label, hideLabel, onChange, ...props }) {
   const dateInputRef = React.useRef()
   const months = createSelectOptions(props.months)
   const [initialYear, initialMonth, initialDay] = getDate(
-    props.initialSelectedDate,
-    months
+    props.initialSelectedDate
   )
   const [year, setYear] = React.useState(initialYear || '')
   const [month, setMonth] = React.useState(initialMonth || 0)


### PR DESCRIPTION
# Description

This PR will make sure that the onChange for day and year will work properly without changing the month.

## How to test
- Add a console.log on line `74` for the DateInput component
- The value should become defined as soon as you filled in at least the day and year. Only day should be undefined.
- You can see the difference by checking out master and add the console.log on line `74`