### PR TITLE
Add alt prop to the Avatar component

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -63,10 +63,10 @@ export const Placeholder = () => (
   </InlineSvg>
 )
 
-export const Avatar = ({ size, src, ...props }) => (
+export const Avatar = ({ size, src, alt, ...props }) => (
   <Wrapper size={size} {...props}>
     {src ? (
-      <StyledImage src={src} alt="Avatar" data-testid="image" />
+      <StyledImage src={src} alt={alt} data-testid="image" />
     ) : (
       <Placeholder />
     )}
@@ -75,6 +75,7 @@ export const Avatar = ({ size, src, ...props }) => (
 
 Avatar.defaultProps = {
   size: 32,
+  alt: 'Avatar',
 }
 
 Avatar.propTypes = {

--- a/src/components/Avatar/index.stories.js
+++ b/src/components/Avatar/index.stories.js
@@ -12,7 +12,10 @@ WithoutImage.story = {
 }
 
 export const WithImage = () => (
-  <Avatar src="https://cdn.ticketswap.com/public/testimonials/201810/0946ce7a-5863-4f9f-9636-5ba8bb8414c3.jpeg" />
+  <Avatar
+    src="https://cdn.ticketswap.com/public/testimonials/201810/0946ce7a-5863-4f9f-9636-5ba8bb8414c3.jpeg"
+    alt="Avatar of Glenn"
+  />
 )
 
 WithImage.story = {


### PR DESCRIPTION
# Description

One way to test your images is by getting them from an alt attribute. Currently it's not possible with this component since all of them will have the same alt attribute. This PR will implement the possibility to add an alt tag yourself. Added an alt tag to the `withImage` storybook.