### PR TITLE
Collapsible with rotate(0deg) instead of rotate()

### DIFF
--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -55,7 +55,7 @@ const Content = styled.div`
 const IconContainer = styled.span`
   display: inline-block;
   pointer-events: none;
-  transform: rotate(${props => props.isOn && '180deg'});
+  transform: rotate(${props => (props.isOn ? '180deg' : '0deg')});
 `
 
 export function Collapsible({ buttonLabel, defaultOn, children, ...props }) {


### PR DESCRIPTION
# Description
`transform: rotate()` is not a valid `css` attribute so change it into `transform: rotate(0deg)`

## Changes

- [x] Check if we want to rotate and rotate 0deg when we don't want to rotate

## Links
https://github.com/TicketSwap/sirius/pull/1962#discussion_r358321843
