### PR TITLE
Overwrite p's margin in alerts

### DIFF
--- a/src/components/Alert/index.js
+++ b/src/components/Alert/index.js
@@ -76,6 +76,7 @@ const Main = styled.div`
 
 const Message = styled.p`
   color: ${color.space};
+  margin: 0;
 `
 
 const Action = styled.button`


### PR DESCRIPTION
# Description
In some contexts p's have a margin bottom. This will make sure that there is none.

## Changes

- [x] Add margin 0 to the message in the Alert

## How to test
- Check if the Solar Alert looks good

## Screenshots
*BEFORE*
<img width="670" alt="Screenshot 2019-12-19 at 17 05 17" src="https://user-images.githubusercontent.com/20326539/71188724-cafe2400-2281-11ea-81e3-29dbc9428a5f.png">
*AFTER*
<img width="670" alt="Screenshot 2019-12-19 at 16 41 21" src="https://user-images.githubusercontent.com/20326539/71188736-d18c9b80-2281-11ea-8666-9b65100362fb.png">
