### PR TITLE
MoneyInput > Disable select as well when MoneyInput is disabled

### DIFF
--- a/src/components/MoneyInput/index.js
+++ b/src/components/MoneyInput/index.js
@@ -62,6 +62,7 @@ export function MoneyInput({
   help,
   validateAmount,
   validateCurrency,
+  disabled,
   ...props
 }) {
   const isCurrencyControlled = typeof props.currency !== 'undefined'
@@ -104,6 +105,7 @@ export function MoneyInput({
                 id={`${inputId}-faux-currency`}
                 label="Currency"
                 hideLabel
+                disabled={disabled}
                 value={
                   isCurrencyControlled ? props.currency.symbol : currency.symbol
                 }
@@ -116,6 +118,7 @@ export function MoneyInput({
             id={`${inputId}-currency`}
             label="Currency"
             hideLabel
+            disabled={disabled}
             floatingMenu
             validate={validateCurrency}
             selectedItem={
@@ -154,6 +157,7 @@ export function MoneyInput({
                   : ''
                 : amount
             }
+            disabled={disabled}
             validate={validateAmount}
             {...props}
             onChange={e => {
@@ -173,6 +177,7 @@ export function MoneyInput({
 
 MoneyInput.defaultProps = {
   onChange: () => {},
+  disabled: false,
 }
 
 MoneyInput.propTypes = {
@@ -200,4 +205,5 @@ MoneyInput.propTypes = {
   initialAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   validateAmount: PropTypes.bool,
   validateCurrency: PropTypes.bool,
+  disabled: PropTypes.bool,
 }

--- a/src/components/MoneyInput/index.stories.js
+++ b/src/components/MoneyInput/index.stories.js
@@ -146,6 +146,24 @@ WithInitialValues.story = {
   name: 'With initial values',
 }
 
+export const WithDisabled = () => (
+  <MoneyInput
+    id="maximum-price"
+    label="Maximum price"
+    placeholder="Enter an amount"
+    currencies={currencies}
+    onChange={e => console.log(e)}
+    initialSelectedCurrency={currencies[2]}
+    initialAmount={240050}
+    help="Leave blank for no maximum price"
+    disabled={true}
+  />
+)
+
+WithDisabled.story = {
+  name: 'Disabled',
+}
+
 export const Controlled = () => <ControlledMoneyInput />
 
 export const WithError = () => (

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -21,6 +21,10 @@ const StyledInput = styled(Input)`
   color: transparent;
   text-shadow: 0 0 0 ${color.space};
   cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+  }
 `
 const LeftAdornment = styled.span`
   margin-right: 10px;


### PR DESCRIPTION
# Description

This PR will implement some small changes to the `MoneyInput` component. It will make sure that the currency select is disabled as well when passing the disabled prop. Added a new story in storybook as well.