### PR TITLE
fix: rename SelectWithSearch to Combobox

### DIFF
--- a/src/components/Combobox/index.js
+++ b/src/components/Combobox/index.js
@@ -4,12 +4,7 @@ import Downshift from 'downshift'
 import { Input, InputMenu, InputMenuList, InputMenuItem } from '../Input'
 import { MagnifyingGlass } from '@ticketswap/comets'
 
-export const SelectWithSearch = ({
-  items,
-  onChange,
-  initialValue,
-  ...props
-}) => (
+export const Combobox = ({ items, onChange, initialValue, ...props }) => (
   <Downshift
     onChange={selection => selection && onChange(selection)}
     itemToString={item => (item ? item.name : '')}
@@ -78,12 +73,12 @@ export const SelectWithSearch = ({
   </Downshift>
 )
 
-SelectWithSearch.defaultProps = {
+Combobox.defaultProps = {
   initialValue: '',
   onChange: () => null,
 }
 
-SelectWithSearch.propTypes = {
+Combobox.propTypes = {
   onChange: PropTypes.func,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,

--- a/src/components/Combobox/index.stories.js
+++ b/src/components/Combobox/index.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { SelectWithSearch } from './'
+import { Combobox } from './'
 import { Flag } from '../Flag'
 import { Envelope, Messenger, Phone } from '@ticketswap/comets'
 
@@ -37,35 +37,23 @@ const countries = [
 ]
 
 export default {
-  title: 'SelectWithSearch',
+  title: 'Combobox',
 }
 
 export const basic = () => (
-  <SelectWithSearch
-    id="selectWithSearch"
-    label="SelectWithSearch"
-    items={tickets}
-  />
+  <Combobox id="Combobox" label="Combobox" items={tickets} />
 )
 
 export const withAdornment = () => (
-  <SelectWithSearch
-    id="selectWithSearch"
-    label="SelectWithSearch"
-    items={countries}
-  />
+  <Combobox id="Combobox" label="Combobox" items={countries} />
 )
 
 export const mixed = () => (
-  <SelectWithSearch
-    id="selectedWithSearch"
-    label="SelectedWithSearch"
-    items={communicationMethods}
-  />
+  <Combobox id="Combobox" label="Combobox" items={communicationMethods} />
 )
 
 export const withInitialValue = () => (
-  <SelectWithSearch
+  <Combobox
     id="country"
     label="Country"
     items={countries}

--- a/src/components/Combobox/index.test.js
+++ b/src/components/Combobox/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
-import { SelectWithSearch } from './'
+import { Combobox } from './'
 
 const countries = [
   { value: 'nl', name: 'Netherlands' },
@@ -8,10 +8,10 @@ const countries = [
   { value: 'de', name: 'Germany' },
 ]
 
-describe('CountryInput', () => {
+describe('ComboboxInput', () => {
   it('renders without crashing', () => {
     const { container, queryByText } = render(
-      <SelectWithSearch id="country" label="Country" items={countries} />
+      <Combobox id="country" label="Country" items={countries} />
     )
     expect(container.firstChild).toBeInTheDocument()
     expect(queryByText(/netherlands/i)).toBeNull()
@@ -19,7 +19,7 @@ describe('CountryInput', () => {
 
   it('shows suggestions upon typing', () => {
     const { getByLabelText, getByText } = render(
-      <SelectWithSearch id="country" label="Country" items={countries} />
+      <Combobox id="country" label="Country" items={countries} />
     )
     fireEvent.change(getByLabelText(/country/i), {
       target: { value: 'nether' },
@@ -29,7 +29,7 @@ describe('CountryInput', () => {
 
   it('handles a passed initial value correctly', () => {
     const { getByLabelText } = render(
-      <SelectWithSearch
+      <Combobox
         id="country"
         label="Country"
         items={countries}
@@ -41,7 +41,7 @@ describe('CountryInput', () => {
 
   it('resets input upon clicking reset-button', () => {
     const { getByLabelText, getByTestId } = render(
-      <SelectWithSearch
+      <Combobox
         id="country"
         label="Country"
         items={countries}
@@ -55,7 +55,7 @@ describe('CountryInput', () => {
   it('calls onChange handler correctly', () => {
     const handler = jest.fn()
     const { getByText, getByLabelText } = render(
-      <SelectWithSearch
+      <Combobox
         id="country"
         label="Country"
         items={countries}

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export { DateInput } from './components/DateInput'
 export { MoneyInput } from './components/MoneyInput'
 export { PhoneInput } from './components/PhoneInput'
 export { TimeInput } from './components/TimeInput'
-export { SelectWithSearch } from './components/SelectWithSearch'
+export { Combobox } from './components/Combobox'
 export { ContentTransition } from './components/ContentTransition'
 export { SkeletonPulse, SkeletonLine } from './components/Skeleton'
 export {


### PR DESCRIPTION
# Description
I was being silly and pushed directly to master, this PR is a fix after a code review from Philipp on https://github.com/TicketSwap/solar/commit/e18be8558d15aa4e171cf1d03675b198a8eb6072

## Changes

- [x] Renamed the SelectWithSearch to ComboBox

## How to test

- Checkout this branch
- Check if the component is renamed.
