### PR TITLE
fix: Invalid proptype in combobox

### DIFF
--- a/src/components/Combobox/index.js
+++ b/src/components/Combobox/index.js
@@ -86,7 +86,7 @@ Combobox.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
-      adornment: PropTypes.func,
+      adornment: PropTypes.object,
     })
   ).isRequired,
   initialValue: PropTypes.string,


### PR DESCRIPTION
# Description
React components are objects instead of function when they are imported as an html objects.
This fixes the prop types in order to support that.

## Changes

- [x] Change the proptype from function to object.

## How to test
- Open the component in your browser
- Select one with adornments
- Check the console if the adornments give errors
