### PR TITLE
feat(Dialog): Add transition callbacks

### DIFF
--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -207,16 +207,20 @@ Dialog.propTypes = {
   defaultOn: PropTypes.bool,
   persist: PropTypes.bool,
   onToggle: PropTypes.func,
+  onEntered: PropTypes.func,
+  onExited: PropTypes.func,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.array]).isRequired,
 }
 
 Dialog.defaultProps = {
   defaultOn: false,
   onToggle: () => {},
+  onEntered: () => {},
+  onExited: () => {},
 }
 
 export function useDialog(config = {}) {
-  const { persist, defaultOn, onToggle, ...props } = config
+  const { persist, defaultOn, onToggle, onEntered, onExited, ...props } = config
   const isOnControlled = React.useCallback(() => {
     return props.on !== undefined
   }, [props.on])
@@ -255,6 +259,8 @@ export function useDialog(config = {}) {
     persist,
     ...props,
     onClick: persist ? props.onClick : callAll(props.onClick, toggle),
+    onEntered,
+    onExited,
   })
 
   return {
@@ -267,8 +273,21 @@ export function useDialog(config = {}) {
   }
 }
 
-export function DialogWindow({ children, on, hide, onEscKeyDown, ...props }) {
-  const [state, mounted] = useTransition({ in: on, timeout: duration })
+export function DialogWindow({
+  children,
+  on,
+  hide,
+  onEscKeyDown,
+  onEntered,
+  onExited,
+  ...props
+}) {
+  const [state, mounted] = useTransition({
+    in: on,
+    timeout: duration,
+    onEntered,
+    onExited,
+  })
   const handleHide = React.useCallback(
     ({ keyCode }) => {
       if (keyCode === 27) {

--- a/src/components/Dialog/index.stories.js
+++ b/src/components/Dialog/index.stories.js
@@ -89,6 +89,8 @@ const MyDialog = ({ children, ...props }) => (
 function HooksDialog() {
   const { hide, getToggleProps, getWindowProps } = useDialog({
     onToggle: on => console.log(on),
+    onEntered: () => console.log('entered'),
+    onExited: () => console.log('exited'),
   })
   return (
     <>


### PR DESCRIPTION
# Description

Adds options for `onEntered` and `onExited` callbacks.

## How to test

- Checkout this branch
- `$ yarn dev`
- http://localhost:9001/?path=/story/dialog--with-hook
- Observe the browser console