### PR TITLE
fix(SpeechBubble): Use children instead of label

### DIFF
--- a/src/components/SpeechBubble/index.js
+++ b/src/components/SpeechBubble/index.js
@@ -68,7 +68,7 @@ const SpeechBubbleContent = styled.div`
   }
 `
 
-export const SpeechBubble = ({ position, label, tailOffset, ...props }) => {
+export const SpeechBubble = ({ children, position, tailOffset, ...props }) => {
   const [verticalPosition, horizontalPosition] = position.split('-')
 
   return (
@@ -78,7 +78,7 @@ export const SpeechBubble = ({ position, label, tailOffset, ...props }) => {
       tailOffset={tailOffset}
       {...props}
     >
-      {label}
+      {children}
     </SpeechBubbleContent>
   )
 }
@@ -95,6 +95,5 @@ SpeechBubble.propTypes = {
     'bottom-right',
     'bottom-left',
   ]),
-  label: PropTypes.object.isRequired,
   tailOffset: PropTypes.number,
 }

--- a/src/components/SpeechBubble/index.stories.js
+++ b/src/components/SpeechBubble/index.stories.js
@@ -15,38 +15,35 @@ export const BottomLeft = () => (
       <Button variant="success">Yes</Button>
       <Button variant="secondary">No</Button>
     </div>
-    <SpeechBubble label={<p>Great, thanks for your feedback!</p>} />
+    <SpeechBubble>
+      <p>Great, thanks for your feedback!</p>
+    </SpeechBubble>
   </>
 )
 
 export const BottomRight = () => (
-  <SpeechBubble
-    label={<p>Great, thanks for your feedback!</p>}
-    position="bottom-right"
-  />
+  <SpeechBubble position="bottom-right">
+    <p>Great, thanks for your feedback!</p>
+  </SpeechBubble>
 )
 
 export const TopLeft = () => (
-  <SpeechBubble
-    label={<p>Great, thanks for your feedback!</p>}
-    position="top-left"
-  />
+  <SpeechBubble position="top-left">
+    <p>Great, thanks for your feedback!</p>
+  </SpeechBubble>
 )
 
 export const TopRight = () => (
-  <SpeechBubble
-    label={<p>Great, thanks for your feedback!</p>}
-    position="top-right"
-  />
+  <SpeechBubble position="top-right">
+    <p>Great, thanks for your feedback!</p>
+  </SpeechBubble>
 )
 
 export const WithOffset = () => (
   <>
-    <SpeechBubble
-      label={<p>Great, thanks for your feedback!</p>}
-      position="top-left"
-      tailOffset={80}
-    />
+    <SpeechBubble position="top-left" tailOffset={80}>
+      <p>Great, thanks for your feedback!</p>
+    </SpeechBubble>
     <p>
       The tail is <strong>here</strong>
     </p>


### PR DESCRIPTION
# Description
The label prop suggested that it should be text only, while it should also be used for links/buttons etc.
With this change comes the possibility to insert any component in the speech bubble.

## Changes

- [x] Removed label prop and added the children