### PR TITLE
fix(avatar): fix avatar flow on dark background

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -13,7 +13,6 @@ const Wrapper = styled.div`
   height: ${props => props.size && `${props.size}px`};
   min-width: ${props => props.size && `${props.size}px`};
   min-height: ${props => props.size && `${props.size}px`};
-  background-color: ${color.stardust};
   border-radius: 50%;
   position: relative;
   overflow: hidden;

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -20,7 +20,6 @@ const Container = styled.div`
   line-height: 0;
   z-index: 1;
   overflow: hidden;
-  background-color: ${color.stardust};
   border-radius: ${props => (props.rounded ? radius.lg : 0)};
   animation-duration: ${duration}ms;
   animation-fill-mode: both;
@@ -30,6 +29,11 @@ const Container = styled.div`
 
 const Placeholder = styled.img`
   vertical-align: middle;
+  transition: opacity ${transition};
+  background-color: ${color.stardust};
+  opacity: ${props => (props.show ? 0 : 1)};
+  width: 100%;
+  height: 100%;
 `
 
 const StyledImage = styled.img`
@@ -152,6 +156,7 @@ export class Image extends Component {
           src={this.placeholderSrc(width, height)}
           aria-hidden="true"
           alt="Placeholder image"
+          show={this.state.loaded}
         />
         <StyledImage
           src={this.state.src}


### PR DESCRIPTION
# What it should do
On dark backgrounds there is a glow outside of the avatar component. This is because of pixel rounding, but we can prevent this by hiding the placeholder once the image is loaded.