### PR TITLE
fix(moneyinput): when controlled input, let the user parse the amount

### DIFF
--- a/src/components/MoneyInput/index.js
+++ b/src/components/MoneyInput/index.js
@@ -87,9 +87,6 @@ export function MoneyInput({
   const parseAmount = value => Math.round(parseFloat(value) * 100) || 0
   const { isMobile } = useDeviceInfo()
   const inputId = `money-input-${useId()}`
-  const controlledAmount = props.amount
-    ? (props.amount / 100).toFixed(2).replace(/\.00$/, '')
-    : ''
 
   return (
     <Label htmlFor={id}>
@@ -153,7 +150,7 @@ export function MoneyInput({
             ref={inputRef}
             hideLabel
             type="number"
-            value={isAmountControlled ? controlledAmount : amount}
+            value={isAmountControlled ? props.amount : amount}
             disabled={disabled}
             validate={validateAmount}
             {...props}
@@ -161,7 +158,9 @@ export function MoneyInput({
               setAmount(e.target.value)
               onChange({
                 currency,
-                amount: parseAmount(e.target.value),
+                amount: isAmountControlled
+                  ? e.target.value
+                  : parseAmount(e.target.value),
               })
             }}
           />

--- a/src/components/MoneyInput/index.stories.js
+++ b/src/components/MoneyInput/index.stories.js
@@ -67,12 +67,13 @@ const currencies = [
 
 function ControlledMoneyInput() {
   const [currency, setCurrency] = React.useState(currencies[2])
-  const [amount, setAmount] = React.useState(2500)
+  const [amount, setAmount] = React.useState(25)
+  const parseAmount = value => Math.round(parseFloat(value) * 100) || 0
 
   React.useEffect(() => {
     console.log({
       currency,
-      amount,
+      amount: parseAmount(amount),
     })
   }, [currency, amount])
 
@@ -92,10 +93,14 @@ function ControlledMoneyInput() {
         <Button size="small" onClick={() => setCurrency(currencies[2])}>
           Set Pounds
         </Button>
-        <Button size="small" variant="success" onClick={() => setAmount(2000)}>
+        <Button size="small" variant="success" onClick={() => setAmount(20)}>
           Set 20
         </Button>
-        <Button size="small" variant="success" onClick={() => setAmount(4050)}>
+        <Button
+          size="small"
+          variant="success"
+          onClick={() => setAmount('40.50')}
+        >
           Set 40,50
         </Button>
       </div>


### PR DESCRIPTION
BREAKING CHANGE: The MoneyInput will now let the parsing of the amount to the parent when it's controlled. This is because otherwise you can't set
amounts in cents. If it's controlled the parent is in full control of what to show.

# Description
When using the MoneyInput controlled, you were not able to change the values after the comma. This PR fixes that issue by making sure the parent is in full control over the value.

## How to test
- Check MoneyInput storybook
- See all work as expected
