### PR TITLE
fix(portal): the portal showed an error when server side rendered

### DIFF
--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -1,8 +1,16 @@
 import PropTypes from 'prop-types'
 import { createPortal } from 'react-dom'
 
+function canUseDOM() {
+  return Boolean(
+    typeof window !== 'undefined' &&
+      window.document &&
+      window.document.createElement
+  )
+}
+
 export const Portal = ({ selector, children }) => {
-  if (typeof document === 'undefined') return null
+  if (!canUseDOM()) return null
   const node = selector ? document.querySelector(selector) : document.body
   return node ? createPortal(children, node) : null
 }


### PR DESCRIPTION
# What it should do
This fixes an issue with server side rendered portals, it should skip it altogether.

## What has been done and why?
- [x] Don't show portal when server side rendered
