### PR TITLE
fix(useLockBodyScroll): Update iOS handling

### DIFF
--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -72,14 +72,8 @@ const Content = styled.div`
 `
 
 export function DialogContent({ children, ...props }) {
-  const ref = useRef(null)
-  useLockBodyScroll(ref)
-
-  return (
-    <Content ref={ref} {...props}>
-      {children}
-    </Content>
-  )
+  useLockBodyScroll()
+  return <Content {...props}>{children}</Content>
 }
 
 export const DialogHeader = styled.header`

--- a/src/hooks/useLockBodyScroll.js
+++ b/src/hooks/useLockBodyScroll.js
@@ -1,227 +1,79 @@
 import { useIsomorphicLayoutEffect as useLayoutEffect_SAFE_FOR_SSR } from '@reach/utils'
 
-// Adopted and modified implementation of `body-scroll-lock`
-// https://github.com/willmcpo/body-scroll-lock
-
-// Older browsers don't support event options, feature detect it.
-let hasPassiveEvents = false
-if (typeof window !== 'undefined') {
-  const passiveTestOptions = {
-    get passive() {
-      hasPassiveEvents = true
-      return undefined
-    },
-  }
-  window.addEventListener('testPassive', null, passiveTestOptions)
-  window.removeEventListener('testPassive', null, passiveTestOptions)
-}
-
 const isIosDevice =
   typeof window !== 'undefined' &&
   window.navigator &&
   window.navigator.platform &&
   /iP(ad|hone|od)/.test(window.navigator.platform)
 
-let locks = []
-let documentListenerAdded = false
 let initialClientY = -1
 let previousBodyOverflowSetting
 let previousBodyPaddingRight
 
-// returns true if `el` should be allowed to receive touchmove events
-const allowTouchMove = el =>
-  locks.some(lock => {
-    if (lock.options.allowTouchMove && lock.options.allowTouchMove(el)) {
-      return true
-    }
-
-    return false
-  })
-
-const preventDefault = rawEvent => {
-  const e = rawEvent || window.event
-
-  // For the case whereby consumers adds a touchmove event listener to document.
-  // Recall that we do document.addEventListener('touchmove', preventDefault, { passive: false })
-  // in disableBodyScroll - so if we provide this opportunity to allowTouchMove, then
-  // the touchmove event on document will break.
-  if (allowTouchMove(e.target)) {
-    return true
-  }
-
-  // Do not prevent if the event has more than one touch (usually meaning this is a multi touch gesture like pinch to zoom)
-  if (e.touches.length > 1) return true
-
-  if (e.preventDefault) e.preventDefault()
-
-  return false
-}
-
-const setOverflowHidden = options => {
-  // Setting overflow on body/documentElement synchronously in Desktop Safari slows down
-  // the responsiveness for some reason. Setting within a setTimeout fixes this.
-  setTimeout(() => {
-    // If previousBodyPaddingRight is already set, don't set it again.
-    if (previousBodyPaddingRight === undefined) {
-      const reserveScrollBarGap =
-        !!options && options.reserveScrollBarGap === true
-      const scrollBarGap =
-        window.innerWidth - document.documentElement.clientWidth
-
-      if (reserveScrollBarGap && scrollBarGap > 0) {
-        previousBodyPaddingRight = document.body.style.paddingRight
-        document.body.style.paddingRight = `${scrollBarGap}px`
-      }
-    }
-
-    // If previousBodyOverflowSetting is already set, don't set it again.
-    if (previousBodyOverflowSetting === undefined) {
-      previousBodyOverflowSetting = document.body.style.overflow
-      document.body.style.overflow = 'hidden'
-    }
-  })
-}
-
-const restoreOverflowSetting = () => {
-  // Setting overflow on body/documentElement synchronously in Desktop Safari slows down
-  // the responsiveness for some reason. Setting within a setTimeout fixes this.
-  setTimeout(() => {
-    if (previousBodyPaddingRight !== undefined) {
-      document.body.style.paddingRight = previousBodyPaddingRight
-
-      // Restore previousBodyPaddingRight to undefined so setOverflowHidden knows it
-      // can be set again.
-      previousBodyPaddingRight = undefined
-    }
-
-    if (previousBodyOverflowSetting !== undefined) {
-      document.body.style.overflow = previousBodyOverflowSetting
-
-      // Restore previousBodyOverflowSetting to undefined
-      // so setOverflowHidden knows it can be set again.
-      previousBodyOverflowSetting = undefined
-    }
-  })
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
-const isTargetElementTotallyScrolled = targetElement =>
-  targetElement
-    ? targetElement.scrollHeight - targetElement.scrollTop <=
-      targetElement.clientHeight
-    : false
-
-const handleScroll = (event, targetElement) => {
-  const clientY = event.targetTouches[0].clientY - initialClientY
-
-  if (allowTouchMove(event.target)) {
-    return false
-  }
-
-  if (targetElement && targetElement.scrollTop === 0 && clientY > 0) {
-    // element is at the top of its scroll
-    return preventDefault(event)
-  }
-
-  if (isTargetElementTotallyScrolled(targetElement) && clientY < 0) {
-    // element is at the top of its scroll
-    return preventDefault(event)
-  }
-
-  event.stopPropagation()
-  return true
-}
-
-export const disableBodyScroll = (targetElement, options) => {
+const lockBodyScroll = options => {
   if (isIosDevice) {
-    return
-    // targetElement must be provided, and disableBodyScroll must not have been
-    // called on this targetElement before.
-    if (!targetElement) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'disableBodyScroll unsuccessful - targetElement must be provided when calling disableBodyScroll on IOS devices.'
-      )
-      return
-    }
-
-    if (
-      targetElement &&
-      !locks.some(lock => lock.targetElement === targetElement)
-    ) {
-      const lock = {
-        targetElement,
-        options: options || {},
-      }
-
-      locks = [...locks, lock]
-
-      targetElement.ontouchstart = event => {
-        if (event.targetTouches.length === 1) {
-          // detect single touch
-          initialClientY = event.targetTouches[0].clientY
-        }
-      }
-      targetElement.ontouchmove = event => {
-        if (event.targetTouches.length === 1) {
-          // detect single touch
-          handleScroll(event, targetElement)
-        }
-      }
-
-      if (!documentListenerAdded) {
-        document.addEventListener(
-          'touchmove',
-          preventDefault,
-          hasPassiveEvents ? { passive: false } : undefined
-        )
-        documentListenerAdded = true
-      }
-    }
+    initialClientY = window.pageYOffset
+    document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${initialClientY}px`
+    document.body.style.width = '100%'
   } else {
-    setOverflowHidden(options)
-    const lock = {
-      targetElement,
-      options: options || {},
-    }
-
-    locks = [...locks, lock]
+    // Setting overflow on body/documentElement synchronously in
+    // Desktop Safari slows down the responsiveness for some reason.
+    // Setting within a requestAnimationFrame fixes this.
+    requestAnimationFrame(() => {
+      // If previousBodyPaddingRight is already set, don't set it
+      // again.
+      if (previousBodyPaddingRight === undefined) {
+        const reserveScrollBarGap =
+          !!options && options.reserveScrollBarGap === true
+        const scrollBarGap =
+          window.innerWidth - document.documentElement.clientWidth
+        if (reserveScrollBarGap && scrollBarGap > 0) {
+          previousBodyPaddingRight = document.body.style.paddingRight
+          document.body.style.paddingRight = `${scrollBarGap}px`
+        }
+      }
+      // If previousBodyOverflowSetting is already set, don't set it
+      // again.
+      if (previousBodyOverflowSetting === undefined) {
+        previousBodyOverflowSetting = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+      }
+    })
   }
 }
 
-export const clearAllBodyScrollLocks = () => {
+const restoreBodyScroll = () => {
   if (isIosDevice) {
-    return
-    // Clear all locks ontouchstart/ontouchmove handlers, and the references
-    locks.forEach(lock => {
-      lock.targetElement.ontouchstart = null
-      lock.targetElement.ontouchmove = null
-    })
-
-    if (documentListenerAdded) {
-      document.removeEventListener(
-        'touchmove',
-        preventDefault,
-        hasPassiveEvents ? { passive: false } : undefined
-      )
-      documentListenerAdded = false
-    }
-
-    locks = []
-
+    document.body.style.removeProperty('overflow')
+    document.body.style.removeProperty('position')
+    document.body.style.removeProperty('top')
+    document.body.style.removeProperty('width')
+    window.scrollTo(0, initialClientY)
     // Reset initial clientY
     initialClientY = -1
   } else {
-    restoreOverflowSetting()
-    locks = []
+    requestAnimationFrame(() => {
+      if (previousBodyPaddingRight !== undefined) {
+        document.body.style.paddingRight = previousBodyPaddingRight
+        // Restore previousBodyPaddingRight to undefined so
+        // setOverflowHidden knows it can be set again.
+        previousBodyPaddingRight = undefined
+      }
+      if (previousBodyOverflowSetting !== undefined) {
+        document.body.style.overflow = previousBodyOverflowSetting
+        // Restore previousBodyOverflowSetting to undefined so
+        // setOverflowHidden knows it can be set again.
+        previousBodyOverflowSetting = undefined
+      }
+    })
   }
 }
 
-export function useLockBodyScroll(targetRef) {
+export function useLockBodyScroll() {
   useLayoutEffect_SAFE_FOR_SSR(() => {
-    disableBodyScroll(targetRef.current, {
-      reserveScrollBarGap: true,
-    })
-    return () => clearAllBodyScrollLocks()
-  }, [targetRef])
+    lockBodyScroll({ reserveScrollBarGap: true })
+    return () => restoreBodyScroll()
+  }, [])
 }


### PR DESCRIPTION
Makes `useLockBodyScroll()` work properly again on iOS.

Fixes https://github.com/TicketSwap/solar/issues/691