### PR TITLE
Revert `gatsby-image` implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@reach/utils": "^0.9.0",
     "@ticketswap/comets": "^2.5.0",
     "compute-scroll-into-view": "^1.0.13",
-    "downshift": "^5.0.5",
-    "gatsby-image": "^2.3.1"
+    "downshift": "^5.0.5"
   }
 }

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import { css } from '@emotion/core'
 import { Image } from '../Image'
+import { color } from '../../theme'
 
 const Wrapper = styled.div`
   vertical-align: middle;
@@ -68,7 +69,8 @@ export const Avatar = ({ size, src, alt, ...props }) => (
         src={src}
         alt={alt}
         data-testid="image"
-        aspectRatio={1 / 1}
+        width={size}
+        height={size}
       />
     ) : (
       <Placeholder />

--- a/src/components/Flag/index.js
+++ b/src/components/Flag/index.js
@@ -1,22 +1,40 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import { color } from '../../theme'
 import { Image } from '../Image'
+
+const StyledImage = styled(Image)`
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  background-color: ${color.spaceLightest};
+  border-radius: 2px;
+  overflow: hidden;
+  width: ${props => (props.size ? `${props.size}px` : '21px')};
+  height: ${props => (props.size ? `${props.size}px` : '15px')};
+  min-width: ${props => (props.size ? `${props.size}px` : '21px')};
+  min-height: ${props => (props.size ? `${props.size}px` : '15px')};
+
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: 3;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    box-shadow: 0 0 0 1px ${color.spaceLightestAlpha} inset;
+  }
+`
 
 export const Flag = ({ countryCode }) => {
   const country = countryCode.toUpperCase()
 
   return (
-    <Image
+    <StyledImage
       src={`https://unpkg.com/flagkit-web@0.0.3/svgs/${country}.svg`}
       alt={`Flag of ${country}`}
-      aspectRatio={15 / 21}
-      style={{
-        width: 21,
-        height: 15,
-        minWidth: 21,
-        minHeight: 15,
-        borderRadius: 2,
-      }}
     />
   )
 }

--- a/src/components/Image/fetchImage.js
+++ b/src/components/Image/fetchImage.js
@@ -1,0 +1,8 @@
+export function fetchImage(src) {
+  const image = new Image()
+  return new Promise((resolve, reject) => {
+    image.src = src
+    image.onload = resolve
+    image.onerror = reject
+  })
+}

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,32 +1,170 @@
-import React from 'react'
-import Img from 'gatsby-image'
-import { radius } from '../../theme'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import { keyframes } from '@emotion/core'
+import { color, transition, duration, radius } from '../../theme'
+import { fetchImage } from './fetchImage'
 
-export function Image({
-  alt,
-  src,
-  srcSet,
-  sizes,
-  aspectRatio,
-  rounded,
-  style,
-}) {
-  return (
-    <Img
-      fluid={{
-        src,
-        aspectRatio,
-        sizes,
-        srcSet,
-      }}
-      style={{ borderRadius: rounded ? radius.lg : 0, ...style }}
-      alt={alt}
-    />
-  )
-}
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
 
-Image.defaultProps = {
-  aspectRatio: 300 / 200,
-  sizes: '100vw',
-  srcSet: '',
+  to {
+    opacity: 1;
+  }
+`
+
+const Container = styled.div`
+  position: relative;
+  line-height: 0;
+  z-index: 1;
+  overflow: hidden;
+  border-radius: ${props => (props.rounded ? radius.lg : 0)};
+  animation-duration: ${duration}ms;
+  animation-fill-mode: both;
+  animation-name: ${fadeIn};
+  backface-visibility: hidden;
+`
+
+const Placeholder = styled.img`
+  vertical-align: middle;
+  transition: opacity ${transition};
+  background-color: ${color.stardust};
+  opacity: ${props => (props.show ? 0 : 1)};
+  width: 100%;
+  height: 100%;
+`
+
+const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
+  vertical-align: middle;
+  transition: opacity ${transition};
+  opacity: ${props => (props.show ? 1 : 0)};
+  position: absolute;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  object-fit: cover;
+`
+
+export class Image extends Component {
+  constructor(props) {
+    super(props)
+    this.handleLoad = this.handleLoad.bind(this)
+  }
+
+  _isMounted = false
+  observer = null
+  initialState = {
+    loaded: false,
+    src: this.placeholderSrc(this.props.width, this.props.height),
+  }
+
+  static propTypes = {
+    src: PropTypes.string.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    rounded: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    width: 1200,
+    height: 800,
+    lazyLoad: true,
+  }
+
+  state = this.initialState
+
+  setImageElementRef = element => (this.imageEl = element)
+
+  placeholderSrc(width, height) {
+    return `data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}"%3E%3C/svg%3E`
+  }
+
+  async handleLoad() {
+    const { src } = this.props
+    try {
+      await fetchImage(src)
+      this._isMounted && this.setState({ loaded: true, src })
+    } catch (error) {
+      this._isMounted && this.setState({ loaded: true })
+    }
+  }
+
+  handleLazyLoad = entries => {
+    if (entries && entries.length && entries[0].intersectionRatio > 0) {
+      if (typeof this.imageEl !== undefined) {
+        this.handleLoad()
+        this.observer.unobserve(this.imageEl)
+      }
+    }
+  }
+
+  initObserver = () => {
+    if (!this.props.lazyLoad) return false
+
+    const config = {
+      root: null, // Specifying `null` watches the document’s viewport
+      rootMargin: '-10px',
+      threshold: 0.01,
+    }
+
+    if (
+      'IntersectionObserver' in window &&
+      'IntersectionObserverEntry' in window &&
+      'intersectionRatio' in window.IntersectionObserverEntry.prototype
+    ) {
+      this.observer = new IntersectionObserver(this.handleLazyLoad, config)
+      this.observer.observe(this.imageEl)
+    } else {
+      this.handleLoad()
+    }
+  }
+
+  componentDidMount() {
+    this._isMounted = true
+    this.initObserver()
+  }
+
+  componentDidUpdate(prevProps) {
+    // Reset image if `src` prop changes
+    if (prevProps.src !== this.props.src) {
+      this.setState(this.initialState, this.initObserver)
+    }
+
+    if (prevProps.lazyLoad !== this.props.lazyLoad && !this.observer) {
+      this.initObserver()
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
+
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  }
+
+  render() {
+    const { src, alt, width, height, ...props } = this.props
+
+    return (
+      <Container {...props}>
+        <Placeholder
+          src={this.placeholderSrc(width, height)}
+          aria-hidden="true"
+          alt="Placeholder image"
+          show={this.state.loaded}
+        />
+        <StyledImage
+          src={this.state.src}
+          ref={this.setImageElementRef}
+          show={this.state.loaded}
+          alt={alt}
+        />
+      </Container>
+    )
+  }
 }

--- a/src/components/Image/index.stories.js
+++ b/src/components/Image/index.stories.js
@@ -12,7 +12,8 @@ export const Basic = () => (
 export const FourByThree = () => (
   <Image
     src="https://images.unsplash.com/photo-1539550298564-8a06769aa728?auto=format&fit=crop&w=400&q=300"
-    aspectRatio={400 / 300}
+    width={400}
+    height={300}
   />
 )
 
@@ -23,23 +24,46 @@ FourByThree.story = {
 export const Square = () => (
   <Image
     src="https://images.unsplash.com/photo-1539550298564-8a06769aa728?auto=format&fit=crop&w=1200&q=80"
-    aspectRatio={1 / 1}
+    width={100}
+    height={100}
   />
 )
 
 export const Rounded = () => (
   <Image
     src="https://images.unsplash.com/photo-1539550298564-8a06769aa728?auto=format&fit=crop&w=1200&q=80"
+    width={400}
+    height={300}
     rounded
   />
 )
 
 export const Lazyload = () => (
   <div style={{ display: 'grid', gridGap: '2rem', padding: '4rem' }}>
-    <Image src="https://images.unsplash.com/photo-1539550298564-8a06769aa728?auto=format&fit=crop&w=1200&q=80" />
-    <Image src="https://images.unsplash.com/photo-1542776949-3a3cae25c727?auto=format&fit=crop&w=1200&q=80" />
-    <Image src="https://images.unsplash.com/photo-1542769494-0cc077eead4b?auto=format&fit=crop&w=1200&q=80" />
-    <Image src="https://images.unsplash.com/photo-1542765570-2d49240a9a92?auto=format&fit=crop&w=1200&q=80" />
-    <Image src="https://images.unsplash.com/photo-1542758854-648ba431dcd1?auto=format&fit=crop&w=1200&q=80" />
+    <Image
+      src="https://images.unsplash.com/photo-1539550298564-8a06769aa728?auto=format&fit=crop&w=1200&q=80"
+      width={300}
+      height={200}
+    />
+    <Image
+      src="https://images.unsplash.com/photo-1542776949-3a3cae25c727?auto=format&fit=crop&w=1200&q=80"
+      width={300}
+      height={200}
+    />
+    <Image
+      src="https://images.unsplash.com/photo-1542769494-0cc077eead4b?auto=format&fit=crop&w=1200&q=80"
+      width={300}
+      height={200}
+    />
+    <Image
+      src="https://images.unsplash.com/photo-1542765570-2d49240a9a92?auto=format&fit=crop&w=1200&q=80"
+      width={300}
+      height={200}
+    />
+    <Image
+      src="https://images.unsplash.com/photo-1542758854-648ba431dcd1?auto=format&fit=crop&w=1200&q=80"
+      width={300}
+      height={200}
+    />
   </div>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,15 +7183,6 @@ fuse.js@^3.4.6:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.6.tgz#545c3411fed88bf2e27c457cab6e73e7af697a45"
   integrity sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==
 
-gatsby-image@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.3.1.tgz#6898e03a489e9b43242562d70079bd8ed10c5d99"
-  integrity sha512-VCJIb2Sp7Dcql+seZ14pqP2yL8oUlLin+HNEb5u8hcn3txkZhzIW3zwPQ3UwfPvi9Em3gBsEClCR6TQSw96J8g==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    object-fit-images "^3.2.4"
-    prop-types "^15.7.2"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -11481,11 +11472,6 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
-
-object-fit-images@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/object-fit-images/-/object-fit-images-3.2.4.tgz#6c299d38fdf207746e5d2d46c2877f6f25d15b52"
-  integrity sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg==
 
 object-inspect@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Reverts TicketSwap/solar#703

Turns out it doesn’t work well in a SSR context and throws errors during re-hydration. Only surfaced when I was refactoring the little video preview image in the site-footer, which is server-rendered. Going to take another stab at this.