### PR TITLE
Make use of correct space variable on card

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -59,7 +59,7 @@ const Container = styled.div`
   @media ${device.tablet} {
     img {
       object-fit: cover;
-      max-height: ${space[272]};
+      max-height: ${space[256]};
     }
   }
 


### PR DESCRIPTION
# Description
272 does not exists as a variable. Therefor the single line card with images was way to height to be useful. Cards look like this now:

![image](https://user-images.githubusercontent.com/22071649/84382579-2387fb80-abeb-11ea-9345-d88d54d5efcc.png)

