### PR TITLE
Adjust z-index on cover

### DIFF
--- a/src/components/Cover/index.js
+++ b/src/components/Cover/index.js
@@ -13,7 +13,7 @@ import {
 
 const Container = styled.div`
   position: relative;
-  z-index: 4;
+  z-index: 5;
   background-color: ${color.space};
   width: 100%;
   height: ${props => (props.fullHeight ? '100vh' : 'auto')};


### PR DESCRIPTION
# Description
When cover has the menubar inside it, the dropdown of the menu should be in front of the content of the page.
