### PR TITLE
fix(checkbox): fix checkbox checked state

### DIFF
--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -127,7 +127,6 @@ Checkbox.defaultProps = {
   onChange: () => {},
   defaultOn: false,
   hideLabel: false,
-  checked: false,
 }
 
 Checkbox.propTypes = {
@@ -136,6 +135,5 @@ Checkbox.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   hideLabel: PropTypes.bool,
   help: PropTypes.string,
-  checked: PropTypes.bool,
   on: PropTypes.bool,
 }


### PR DESCRIPTION
The checkbox had a default prop named checked, this meant that the checkbox stayed checked when
changed, forever.

Fix #893

