### PR TITLE
docs(issue templates): add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1.Bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a bug report for Solar
+title: ''
+labels: bug
+assignees: glenngijsberts, RobVermeer, Roohn
+
+---
+
+## Problem description
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+Steps to reproduce the behavior.
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behaviour
+A clear and concise description of what you expected to happen.
+
+## Additional context
+Add any other context about the problem here. Such as links, screenshots, environment, version etc.

--- a/.github/ISSUE_TEMPLATE/2.Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2.Feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Request a new feature for Solar
+title: ''
+labels: feature request
+assignees: glenngijsberts, RobVermeer, Roohn
+
+---
+
+## Feature description
+A clear and concise description of what the feature is.
+
+## Additional context
+Add any other context about the feature here. Such as links, wireframes, designs, etc.

--- a/.github/ISSUE_TEMPLATE/3.Improvement_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/3.Improvement_suggestion.md
@@ -1,0 +1,17 @@
+---
+name: Improvement suggestion
+about: Suggest quick wins and improvements for Solar
+title: ''
+labels: improvement
+assignees: glenngijsberts, RobVermeer, Roohn
+
+---
+
+## Improvement description
+A clear and concise description of what the improvement is.
+
+## Expected behaviour
+A clear and concise description of what you expected to happen.
+
+## Additional context
+Add any other context about the improvement here. Such as links, screenshots, examples, etc.

--- a/.github/ISSUE_TEMPLATE/4.Maintenance_task.md
+++ b/.github/ISSUE_TEMPLATE/4.Maintenance_task.md
@@ -1,0 +1,17 @@
+---
+name: Maintenance task
+about: Create a maintenance task for Solar
+title: ''
+labels: maintenance
+assignees: glenngijsberts, RobVermeer, Roohn
+
+---
+
+## Task description
+A clear and concise description of what the maintenance task is.
+
+## Expected outcome
+A clear and concise description of what the outcome will be.
+
+## Additional context
+Add any other context about the task here. Such as links, references, etc.

--- a/.github/ISSUE_TEMPLATE/5.Discussion.md
+++ b/.github/ISSUE_TEMPLATE/5.Discussion.md
@@ -1,0 +1,17 @@
+---
+name: Discussion
+about: Start a new discussion for Solar
+title: ''
+labels: discussion
+assignees: glenngijsberts, RobVermeer, Roohn
+
+---
+
+## Discussion subject
+A clear and concise description of what the discussion is about.
+
+## Your opinion
+Tell us what you think is the solution to the problem described.
+
+## Additional context
+Add any other context about the subject here. Such as links, screenshots, environment, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
# Description

This PR should implement new issue templates for Solar. Also added the new labels that are coming with the issue templates.
