### PR TITLE
fix(Button): fix Warning: Received `false` for a non-boolean

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -329,15 +329,14 @@ const Adornment = styled.span`
 `
 
 const Button: React.FC<ButtonProps> = React.forwardRef(
-  ({ children, onClick, ...props }, ref: React.Ref<HTMLButtonElement>) => (
-    <StyledButton
-      ref={ref}
-      onClick={props.loading ? () => null : onClick}
-      {...props}
-    >
-      {props.loading || props.leftAdornment ? (
+  (
+    { children, onClick, loading, ...props },
+    ref: React.Ref<HTMLButtonElement>
+  ) => (
+    <StyledButton ref={ref} onClick={loading ? () => null : onClick} {...props}>
+      {loading || props.leftAdornment ? (
         <Adornment>
-          {props.loading ? <Spinner size={24} /> : props.leftAdornment}
+          {loading ? <Spinner size={24} /> : props.leftAdornment}
         </Adornment>
       ) : null}
       {children}


### PR DESCRIPTION
# Description

Long story short: loading is a native html attribute, so when we spread the `{...props}` attribute on the html element it's giving a warning (from emotion I think) if the value is not correct. This PR will fix it, by making sure that the loading prop is not spread on the styled component.

More info: https://github.com/styled-components/styled-components/issues/1198 (I know it's styled-components and not emotion, but it seems to have the same problems).

## How to test

- Checkout this branch
- yarn storybook
- go to the loading button story
- Verify that you don't get the same error as provided below
- You can checkout master the see the error yourself

<img width="510" alt="Screenshot 2020-11-18 at 19 10 15" src="https://user-images.githubusercontent.com/14276144/99570856-d5b1c380-29d2-11eb-95e3-81b61cb086da.png">
