### PR TITLE
fix(Combobox): fix normalize functionality for combobox

### DIFF
--- a/src/components/Combobox/index.tsx
+++ b/src/components/Combobox/index.tsx
@@ -77,7 +77,7 @@ export const Combobox = ({
                             .includes(inputValue.toLowerCase())) ||
                         (normalize &&
                           normalizeChars(item.name.toLowerCase()).includes(
-                            inputValue.toLowerCase()
+                            normalizeChars(inputValue.toLowerCase())
                           ))
                     )
                     .map((item, index) => (


### PR DESCRIPTION
# Description

Recently we introduced the functionality to normalize the search results of the combobox. This means that the search value will always fall back to regular and lowercase characters instead of special characters. There was only one problem: using special characters wouldn't match the search results. This commit wil fix that.

https://github.com/TicketSwap/solar/pull/993


## Changes

- [x] Normalize both the input value as the search results

## How to test

- Checkout this branch
- `$ yarn storybook`
- Use the 'normalize' story of the Combobox
- Please test carefully, you can add more options to `banks` at `Combobox/index.stories.tsx`.

Example:

- Input value Itaú will fallback to Itau. This will make sure that resuls like `ITAÚ UNIBANCO HOLDING BM S.A (652)` will show up as well since that is also normalized.

