### PR TITLE
Adornment and loading not showing on Toggle

### DIFF
--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -11,8 +11,6 @@ export interface ToggleProps {
 }
 
 export const Toggle: React.FC<ToggleProps> = ({
-  loading,
-  adornment,
   defaultOn = false,
   onToggle = () => null,
   ...props


### PR DESCRIPTION
# Description
The adornment on the toggle switch was not working anymore since migrating to TypeScript.
This was because the loading and adornment props were destructed from the props, so that the switch didn't have them anymore.