### PR TITLE
Remove custom hyphenation

### DIFF
--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -18,35 +18,6 @@ export const baseTextStyles = css`
   @media ${device.tablet} {
     font-size: ${fontSize[18]};
   }
-
-  /* Hyphenation */
-  /* http://clagnut.com/blog/2395 */
-
-  -webkit-hyphens: auto;
-  -webkit-hyphenate-limit-before: 3;
-  -webkit-hyphenate-limit-after: 3;
-  -webkit-hyphenate-limit-chars: 6 3 3;
-  -webkit-hyphenate-limit-lines: 2;
-  -webkit-hyphenate-limit-last: always;
-  -webkit-hyphenate-limit-zone: 8%;
-
-  -moz-hyphens: auto;
-  -moz-hyphenate-limit-chars: 6 3 3;
-  -moz-hyphenate-limit-lines: 2;
-  -moz-hyphenate-limit-last: always;
-  -moz-hyphenate-limit-zone: 8%;
-
-  -ms-hyphens: auto;
-  -ms-hyphenate-limit-chars: 6 3 3;
-  -ms-hyphenate-limit-lines: 2;
-  -ms-hyphenate-limit-last: always;
-  -ms-hyphenate-limit-zone: 8%;
-
-  hyphens: auto;
-  hyphenate-limit-chars: 6 3 3;
-  hyphenate-limit-lines: 2;
-  hyphenate-limit-last: always;
-  hyphenate-limit-zone: 8%;
 `
 
 export interface TextProps extends React.HTMLAttributes<HTMLSpanElement> {


### PR DESCRIPTION
# Description
After a lot of debate about the usage of `hyphens: auto` we decided to remove it and use the default hyphenation settings.
What this comes down to is that hyphens are only applied when we set a soft hyphen (`&shy;`) in the text. (`hyphens: manual`)

## Changes
Removed all custom hyphenation settings.

## How to test
- `yarn storybook`
- Go to the `heading` story to check the hyphenation.