### PR TITLE
feat(MenuButton): Use @reach/menu-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@reach/accordion": "^0.11.2",
     "@reach/auto-id": "^0.11.2",
     "@reach/dialog": "^0.11.2",
+    "@reach/menu-button": "^0.12.1",
     "@reach/tabs": "^0.11.2",
     "@reach/tooltip": "0.11.2",
     "@reach/utils": "^0.11.2",

--- a/src/components/MenuButton/index.stories.tsx
+++ b/src/components/MenuButton/index.stories.tsx
@@ -1,47 +1,44 @@
 import React from 'react'
-import { MenuButton } from '.'
-import { CustomDropdownPostion } from '../CustomDropdown'
-
-const items = [
-  { name: 'English', value: 'en' },
-  { name: 'Nederlands', value: 'nl' },
-  { name: 'German', value: 'de' },
-]
+import { Menu, MenuList, MenuButton, MenuItem, MenuLink } from './'
 
 export default {
   title: 'MenuButton',
 }
 
 export const Basic = () => (
-  <div style={{ padding: '2rem' }}>
-    <span>
-      Language:{' '}
-      <MenuButton
-        items={items}
-        initialSelectedItem={items[0]}
-        onChange={item => console.log(item)}
-      />
-    </span>
-  </div>
+  <Menu>
+    <MenuButton>
+      Actions <span aria-hidden>▾</span>
+    </MenuButton>
+    <MenuList>
+      <MenuItem onSelect={() => alert('Download')}>Download</MenuItem>
+      <MenuItem onSelect={() => alert('Copy')}>Create a Copy</MenuItem>
+      <MenuItem onSelect={() => alert('Mark as Draft')}>Mark as Draft</MenuItem>
+      <MenuItem onSelect={() => alert('Delete')}>Delete</MenuItem>
+      <MenuLink as="a" href="https://ticketswap.com/">
+        Visit TicketSwap
+      </MenuLink>
+    </MenuList>
+  </Menu>
 )
 
 export const Top = () => (
-  <div
-    style={{
-      display: 'flex',
-      alignItems: 'flex-end',
-      padding: '2rem',
-      height: '100vh',
-    }}
-  >
-    <span>
-      Language:{' '}
-      <MenuButton
-        items={items}
-        dropdownPosition={CustomDropdownPostion.top}
-        onChange={item => console.log(item)}
-        initialSelectedItem={items[1]}
-      />
-    </span>
+  <div style={{ marginTop: '80vh' }}>
+    <Menu>
+      <MenuButton>
+        Actions <span aria-hidden>▾</span>
+      </MenuButton>
+      <MenuList>
+        <MenuItem onSelect={() => alert('Download')}>Download</MenuItem>
+        <MenuItem onSelect={() => alert('Copy')}>Create a Copy</MenuItem>
+        <MenuItem onSelect={() => alert('Mark as Draft')}>
+          Mark as Draft
+        </MenuItem>
+        <MenuItem onSelect={() => alert('Delete')}>Delete</MenuItem>
+        <MenuLink as="a" href="https://ticketswap.com/">
+          Visit TicketSwap
+        </MenuLink>
+      </MenuList>
+    </Menu>
   </div>
 )

--- a/src/components/MenuButton/index.test.tsx
+++ b/src/components/MenuButton/index.test.tsx
@@ -1,34 +1,30 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
-import { MenuButton } from './'
+import { render } from '@testing-library/react'
+import { Menu, MenuButton, MenuItem, MenuLink, MenuList } from './'
 
-const items = [
-  { name: 'English', value: 'en' },
-  { name: 'Nederlands', value: 'nl' },
-  { name: 'German', value: 'de' },
-]
-const handleChange = jest.fn()
+const handleOnSelect = jest.fn()
 const MyMenuButton = () => (
-  <MenuButton
-    items={items}
-    onChange={item => handleChange(item)}
-    initialSelectedItem={items[0]}
-  />
+  <Menu>
+    <MenuButton>
+      Actions <span aria-hidden>▾</span>
+    </MenuButton>
+    <MenuList>
+      <MenuItem onSelect={() => handleOnSelect('Download')}>Download</MenuItem>
+      <MenuItem onSelect={() => handleOnSelect('Copy')}>Create a Copy</MenuItem>
+      <MenuItem onSelect={() => handleOnSelect('Mark as Draft')}>
+        Mark as Draft
+      </MenuItem>
+      <MenuItem onSelect={() => handleOnSelect('Delete')}>Delete</MenuItem>
+      <MenuLink as="a" href="https://ticketswap.com/">
+        Visit TicketSwap
+      </MenuLink>
+    </MenuList>
+  </Menu>
 )
 
 describe('MenuButton', () => {
   it('renders without crashing', () => {
     const { container } = render(<MyMenuButton />)
     expect(container.firstChild).toBeInTheDocument()
-  })
-
-  it('handles selection correctly', () => {
-    const { getByText, queryByText } = render(<MyMenuButton />)
-    expect(queryByText(/nederlands/i)).toBeNull()
-    fireEvent.click(getByText(/english/i))
-    fireEvent.click(getByText(/nederlands/i))
-    expect(getByText(/nederlands/i)).toBeInTheDocument()
-    expect(handleChange).toHaveBeenCalledTimes(1)
-    expect(handleChange).toHaveBeenCalledWith(items[1])
   })
 })

--- a/src/components/MenuButton/index.tsx
+++ b/src/components/MenuButton/index.tsx
@@ -4,14 +4,17 @@ import {
   MenuItem as ReachMenuItem,
   MenuLink as ReachMenuLink,
   MenuProps,
-  MenuListProps,
+  MenuListProps as ReachMenuListProps,
   useMenuButtonContext,
+  MenuItemProps,
+  MenuLinkProps as ReachMenuLinkProps,
 } from '@reach/menu-button'
 import styled from '@emotion/styled'
 import { color, easing, radius, shadow, space } from '../../theme'
 import React from 'react'
 import { css, Global } from '@emotion/react'
 import { useTransition } from '../../hooks'
+import { TransitionState } from '../../hooks/useTransition'
 
 const DURATION = 200
 
@@ -30,8 +33,11 @@ export const Menu = ({ children, ...props }: MenuProps) => {
   )
 }
 
-// @ts-ignore
-const StyledMenuList = styled(ReachMenuList)`
+export interface MenuListProps extends ReachMenuListProps {
+  state: boolean | TransitionState
+}
+
+const StyledMenuList = styled<React.FC<MenuListProps>>(ReachMenuList)`
   background-color: ${color.nova};
   border-radius: ${radius.lg};
   box-shadow: ${shadow.strong};
@@ -70,7 +76,7 @@ const StyledMenuList = styled(ReachMenuList)`
     transform ${DURATION}ms ${easing.easeInOutCubic};
 `
 
-export const MenuList = ({ children, ...props }: MenuListProps) => {
+export const MenuList = ({ children, ...props }: ReachMenuListProps) => {
   const { isExpanded } = useMenuButtonContext()
   const [state] = useTransition({
     in: isExpanded,
@@ -84,14 +90,16 @@ export const MenuList = ({ children, ...props }: MenuListProps) => {
   )
 }
 
-// @ts-ignore
-export const MenuItem = styled(ReachMenuItem)`
+export const MenuItem = styled<React.FC<MenuItemProps>>(ReachMenuItem)`
   padding: ${space[8]} ${space[16]};
   cursor: pointer;
 `
 
-// @ts-ignore
-export const MenuLink = styled(ReachMenuLink)`
+export interface MenuLinkProps extends ReachMenuLinkProps {
+  href: string | undefined
+}
+
+export const MenuLink = styled<React.FC<MenuLinkProps>>(ReachMenuLink)`
   padding: ${space[8]} ${space[16]};
   display: block;
 `

--- a/src/components/MenuButton/index.tsx
+++ b/src/components/MenuButton/index.tsx
@@ -1,147 +1,99 @@
-import React, { useState, useEffect, useRef } from 'react'
+import {
+  Menu as ReachMenu,
+  MenuList as ReachMenuList,
+  MenuItem as ReachMenuItem,
+  MenuLink as ReachMenuLink,
+  MenuProps,
+  MenuListProps,
+  useMenuButtonContext,
+} from '@reach/menu-button'
 import styled from '@emotion/styled'
-import {
-  CustomDropdown,
-  CustomDropdownItem as Item,
-  CustomDropdownPostion,
-} from '../CustomDropdown'
-import { color } from '../../theme'
-import {
-  useKeyPress,
-  useOnClickOutside,
-  usePrevious,
-  useTransition,
-} from '../../hooks'
-import { TransitionState } from '../../hooks/useTransition'
+import { color, easing, radius, shadow, space } from '../../theme'
+import React from 'react'
+import { css, Global } from '@emotion/react'
+import { useTransition } from '../../hooks'
 
-interface MenuButtonItemPropType {
-  name: string
-  value: string
-}
+const DURATION = 200
 
-export interface MenuButtonProps {
-  dropdownPosition?: CustomDropdownPostion
-  items: MenuButtonItemPropType[]
-  onChange: (selectedItem: MenuButtonItemPropType) => void
-  initialSelectedItem: MenuButtonItemPropType
-}
-
-const duration = 200
-
-const Wrapper = styled.div`
-  display: inline-block;
-  position: relative;
-`
-
-interface StyledButton {
-  clickThrough?: boolean
-}
-
-const Button = styled.button<StyledButton>`
-  font-size: inherit;
-  color: ${color.spaceLight};
-  outline: 0;
-  pointer-events: ${props => (props.clickThrough ? 'none' : 'false')};
-
-  &:focus {
-    box-shadow: none;
-  }
-`
-
-interface StyledMenuContainer {
-  transitionState:
-    | TransitionState.ENTERED
-    | TransitionState.ENTERING
-    | TransitionState.EXITED
-    | TransitionState.EXITING
-    | boolean // @TODO: Why is `state` boolean | TransitionState?
-  dropdownPosition?: CustomDropdownPostion
-}
-
-const MenuContainer = styled.div<StyledMenuContainer>`
-  position: absolute;
-  z-index: 2;
-  left: 50%;
-  bottom: 0;
-  opacity: ${props =>
-    props.transitionState === 'entering' || props.transitionState === 'entered'
-      ? 1
-      : 0};
-  transform: ${props =>
-    props.transitionState === 'entering' ||
-    props.transitionState === 'entered' ||
-    props.transitionState === 'exiting'
-      ? 'translate3d(-50%,0,0)'
-      : `translate3d(-50%,${props.dropdownPosition === 'top' ? -1 : 1}rem,0)`};
-  transition: opacity ${duration}ms ease-out, transform ${duration}ms ease-out;
-`
-
-const Menu = styled.div`
-  display: inline-block;
-`
-
-export const MenuButton: React.FC<MenuButtonProps> = ({
-  items,
-  dropdownPosition,
-  onChange,
-  initialSelectedItem,
-  ...props
-}) => {
-  const [selectedItem, setSelectedItem] = useState(
-    initialSelectedItem || items[0] // @TODO: Remove this after TS migration
+export const Menu = ({ children, ...props }: MenuProps) => {
+  return (
+    <ReachMenu {...props}>
+      {children}
+      <Global
+        styles={css`
+          :root {
+            --reach-menu-button: 1;
+          }
+        `}
+      />
+    </ReachMenu>
   )
-  const previousItem = usePrevious(selectedItem)
-  const [isOpen, setIsOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-  useOnClickOutside(ref, () => setIsOpen(false))
-  const esc = useKeyPress('Escape')
-  const [state, mounted] = useTransition({ in: isOpen, timeout: duration })
+}
 
-  useEffect(() => {
-    // Close menu with Esc key
-    if (isOpen && esc) setIsOpen(false)
-  }, [isOpen, esc])
+// @ts-ignore
+const StyledMenuList = styled(ReachMenuList)`
+  background-color: ${color.nova};
+  border-radius: ${radius.lg};
+  box-shadow: ${shadow.strong};
+  padding-top: ${space[16]};
+  padding-bottom: ${space[16]};
+  margin-top: ${space[8]};
+  margin-bottom: ${space[8]};
 
-  useEffect(() => {
-    if (
-      previousItem &&
-      previousItem !== selectedItem &&
-      selectedItem !== initialSelectedItem
-    ) {
-      Boolean(onChange) && onChange(selectedItem)
+  [data-reach-menu-item][data-selected] {
+    background-color: ${color.stardust};
+  }
+
+  [data-reach-menu-item] {
+    :focus,
+    :active {
+      outline: none;
+      box-shadow: 0 0 0 ${space[4]} ${color.earthLightestAlpha};
     }
-  }, [selectedItem, previousItem, initialSelectedItem, onChange])
+  }
+
+  :focus,
+  :active {
+    outline: none;
+    box-shadow: 0 0 0 ${space[4]} ${color.earthLightestAlpha};
+  }
+
+  opacity: ${props =>
+    props.state === 'entering' || props.state === 'entered' ? 1 : 0};
+  transform: ${props =>
+    props.state === 'entering' ||
+    props.state === 'entered' ||
+    props.state === 'exiting'
+      ? 'translateY(0)'
+      : `translateY(1rem)`};
+  transition: opacity ${DURATION}ms ${easing.easeInOutCubic},
+    transform ${DURATION}ms ${easing.easeInOutCubic};
+`
+
+export const MenuList = ({ children, ...props }: MenuListProps) => {
+  const { isExpanded } = useMenuButtonContext()
+  const [state] = useTransition({
+    in: isExpanded,
+    timeout: DURATION,
+  })
 
   return (
-    <Wrapper {...props}>
-      <Button onClick={() => setIsOpen(true)} clickThrough={isOpen}>
-        {selectedItem.name} <span aria-hidden>▾</span>
-      </Button>
-
-      {mounted && (
-        <MenuContainer
-          transitionState={state}
-          ref={ref}
-          dropdownPosition={dropdownPosition}
-        >
-          <Menu>
-            <CustomDropdown withArrow position={dropdownPosition} distance={4}>
-              {items.map(item => (
-                <Item
-                  key={item.value}
-                  active={selectedItem && selectedItem.value === item.value}
-                  onClick={() => {
-                    setSelectedItem(item)
-                    setIsOpen(false)
-                  }}
-                >
-                  {item.name}
-                </Item>
-              ))}
-            </CustomDropdown>
-          </Menu>
-        </MenuContainer>
-      )}
-    </Wrapper>
+    <StyledMenuList state={state} {...props}>
+      {children}
+    </StyledMenuList>
   )
 }
+
+// @ts-ignore
+export const MenuItem = styled(ReachMenuItem)`
+  padding: ${space[8]} ${space[16]};
+  cursor: pointer;
+`
+
+// @ts-ignore
+export const MenuLink = styled(ReachMenuLink)`
+  padding: ${space[8]} ${space[16]};
+  display: block;
+`
+
+export { MenuButton } from '@reach/menu-button'

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,13 @@ export {
   fieldStyles,
 } from './components/Input'
 export { Logo } from './components/Logo'
-export { MenuButton } from './components/MenuButton'
+export {
+  Menu,
+  MenuList,
+  MenuButton,
+  MenuItem,
+  MenuLink,
+} from './components/MenuButton'
 export { Portal } from './components/Portal'
 export { SpeechBubble } from './components/SpeechBubble'
 export { Spinner } from './components/Spinner'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,12 +1915,28 @@
     "@reach/utils" "0.11.2"
     tslib "^2.0.0"
 
+"@reach/auto-id@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.12.1.tgz#2e4a7250d2067ec16a9b4ea732695bc75572405c"
+  integrity sha512-s8cdY6dF0hEBB/28BbidB2EX6JfEBVIWLP6S2Jg0Xqq2H3xijL+zrsjL40jACwXRkignjuP+CvYsuFuO0+/GRA==
+  dependencies:
+    "@reach/utils" "0.12.1"
+    tslib "^2.0.0"
+
 "@reach/descendants@0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.11.2.tgz#49ea1b5eb91aba8ae6dce57f6575c38aff1f9756"
   integrity sha512-63Wdx32/RyjGRJc4UZKK7F1sIrb6jeGkDwvQH0hv0lRAhEjsiSQ1t2JTYDml3testFP48J0B2xS7JzNeY0zoQw==
   dependencies:
     "@reach/utils" "0.11.2"
+    tslib "^2.0.0"
+
+"@reach/descendants@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.12.1.tgz#dd124e15ee66327692043fea798cc4b6232c1522"
+  integrity sha512-lvpyQ2EixbN7GvT8LyjZfHWQZz/cKwa/p7E26YQOT8nvxm4ABKRGxaSTwUA7D+MLOX6NtHo2qyZ9wippaXB5sQ==
+  dependencies:
+    "@reach/utils" "0.12.1"
     tslib "^2.0.0"
 
 "@reach/dialog@^0.11.2":
@@ -1935,10 +1951,33 @@
     react-remove-scroll "^2.3.0"
     tslib "^2.0.0"
 
+"@reach/menu-button@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.12.1.tgz#73976bd101431c67351a811f2fbf76ddefbecf53"
+  integrity sha512-hsq3TGBLutU7u+Gwhff6KJeanbabdODtfSTi947DaoJ/HHZVOjYUldNEBNeO3DeBE/bOv2TjYe3D4rw11m25Tg==
+  dependencies:
+    "@reach/auto-id" "0.12.1"
+    "@reach/descendants" "0.12.1"
+    "@reach/popover" "0.12.1"
+    "@reach/utils" "0.12.1"
+    prop-types "^15.7.2"
+    tslib "^2.0.0"
+
 "@reach/observe-rect@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
   integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
+
+"@reach/popover@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.12.1.tgz#d35dbff5d7751600ac9a2a0703e8585b8820964d"
+  integrity sha512-gpwd7mQK51xzDLtf+qCHsxQxeMokKNTssgoK2MIJVkPpMDrSK+rskcZswpWjHSGx9EQ27bxZb/3A0GjkN1rPLg==
+  dependencies:
+    "@reach/portal" "0.12.1"
+    "@reach/rect" "0.12.1"
+    "@reach/utils" "0.12.1"
+    tabbable "^4.0.0"
+    tslib "^2.0.0"
 
 "@reach/portal@0.11.2":
   version "0.11.2"
@@ -1948,6 +1987,14 @@
     "@reach/utils" "0.11.2"
     tslib "^2.0.0"
 
+"@reach/portal@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.12.1.tgz#995858a6e758d9446870937b60b8707a2efa11cb"
+  integrity sha512-Lhmtd2Qw1DzNZ2m0GHNzCu+2TYUf6kBREPSQJf44AP6kThRs02p1clntbJcmW/rrpYFYgFNbgf5Lso7NyW9ZXg==
+  dependencies:
+    "@reach/utils" "0.12.1"
+    tslib "^2.0.0"
+
 "@reach/rect@0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.11.2.tgz#bc92f97f87e81d1307054fd41c40874d3fbf5491"
@@ -1955,6 +2002,16 @@
   dependencies:
     "@reach/observe-rect" "1.2.0"
     "@reach/utils" "0.11.2"
+    prop-types "^15.7.2"
+    tslib "^2.0.0"
+
+"@reach/rect@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.12.1.tgz#5b018da4dccca852df21668ae54d5941c16f5bf7"
+  integrity sha512-c+EjKc+9ud832MpmYKsxu+2R0/XHyXk47ik/N+DIHsugIgKJn2B34r4r9benqsaHncUO1IQk5rTv40D7x+yR0g==
+  dependencies:
+    "@reach/observe-rect" "1.2.0"
+    "@reach/utils" "0.12.1"
     prop-types "^15.7.2"
     tslib "^2.0.0"
 
@@ -1996,6 +2053,15 @@
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.11.2.tgz#be1f03650db56fd67a16d3fc70e5262cdb139cec"
   integrity sha512-fBTolYj+rKTROXmf0zHO0rCWSvw7J0ALmYj5QxW4DmITMOH5uyRuWDWOfqohIGFbOtF/sum50WTB3tvx76d+Aw==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^2.0.0"
+    warning "^4.0.3"
+
+"@reach/utils@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.12.1.tgz#02b9c15ba5cddf23e16f2d2ca77aef98a9702607"
+  integrity sha512-5uH4OgO+GupAzZuf3b6Wv/9uC6NdMBlxS6FSKD6YqSxP4QJ0vjD34RVon6N/RMRORacCLyD/aaZIA7283YgeOg==
   dependencies:
     "@types/warning" "^3.0.0"
     tslib "^2.0.0"
@@ -6547,7 +6613,7 @@ debug@^3.0.0, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -9244,7 +9310,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -11402,11 +11468,6 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -11415,32 +11476,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -11496,11 +11535,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -16324,6 +16358,11 @@ symbol.prototype.description@^1.0.0:
     es-abstract "^1.18.0-next.1"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
+
+tabbable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
+  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
# Description
The menubutton from `@reach` has way beter accessibility and keyboard functionality.
Next to that I tried to make it so this menubutton can be used in more cases than it did before (more styling options)

## Changes
- [x] Added `@reach/menu-button` and used it in our menuButton component.

## How to test
1. `yarn storybook`
2. Check out the menu button
3. You should be able to navigate the menu with your keyboard (wasn't possible before)

## Screenshots
| Without focus | With focus |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/22071649/102464369-8cde4080-404c-11eb-9e3d-5bc48ba9be0a.png) | ![image](https://user-images.githubusercontent.com/22071649/102464396-9667a880-404c-11eb-9cdb-a77e6d87be44.png)


