### PR TITLE
fix(Dialog): Fix the shadows of dialog component with longer content

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -10,6 +10,7 @@ import {
   radius,
   color,
   easing,
+  gradients,
 } from '../../theme'
 import { useLockBodyScroll, usePrevious, useTransition } from '../../hooks'
 import { TransitionState } from '../../hooks/useTransition'
@@ -194,8 +195,8 @@ const BodyWrapper = styled.div`
     top: 0;
     background-image: linear-gradient(
       to bottom,
-      rgba(255, 255, 255, 1),
-      rgba(255, 255, 255, 0)
+      ${gradients.nova},
+      ${gradients.novaAlpha}
     );
   }
 
@@ -203,8 +204,8 @@ const BodyWrapper = styled.div`
     bottom: 0;
     background-image: linear-gradient(
       to bottom,
-      rgba(255, 255, 255, 0),
-      rgba(255, 255, 255, 1)
+      ${gradients.novaAlpha},
+      ${gradients.nova}
     );
   }
 `

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -79,6 +79,9 @@ export const globalStyles = css`
 
     --shadowLighterAlpha: rgba(0, 19, 25, 0.2);
     --shadowLightestAlpha: rgba(0, 19, 25, 0.1);
+
+    --gradientNova: rgba(255, 255, 255, 1);
+    --gradientNovaAlpha: rgba(255, 255, 255, 0);
   }
 
   [data-theme='dark'] {
@@ -156,6 +159,9 @@ export const globalStyles = css`
 
     --shadowLighterAlpha: rgba(0, 19, 25, 0.2);
     --shadowLightestAlpha: rgba(0, 19, 25, 0.1);
+
+    --gradientNova: rgba(26, 33, 41, 1);
+    --gradientNovaAlpha: rgba(26, 33, 41, 0);
   }
 
   ::selection {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -172,6 +172,11 @@ export const sizes = {
   desktop: 2560,
 }
 
+export const gradients = {
+  nova: 'var(--gradientNova)',
+  novaAlpha: 'var(--gradientNovaAlpha)',
+}
+
 export const device = {
   mobile: `(min-width: ${sizes.mobile / 16}em)`,
   mobileM: `(min-width: ${sizes.mobileM / 16}em)`,


### PR DESCRIPTION
# Description

Introducing new gradients variables and used this to fix the dark mode of shadow colors in dialogs when the content is longer. 

## Changes

- [x] Added gradients variables
- [x] Fixed dialog shadows on dark mode 

## How to test

- Checkout this branch
- `$ yarn storybook`
- Checkout dialog story "WithLongBody" and verify everything is working as expected.
- If you want to see dark mode you should inspect the dialog, and add `data-theme="dark"` to the html inside the iFrame 

## Screenshots

<img width="1318" alt="Screenshot 2021-01-29 at 11 42 21" src="https://user-images.githubusercontent.com/14276144/106265253-0f027d00-6227-11eb-9567-f4f68ef8d51e.png">
<img width="1326" alt="Screenshot 2021-01-29 at 11 46 23" src="https://user-images.githubusercontent.com/14276144/106265635-9f40c200-6227-11eb-9c3e-512ed782bf7d.png">