### PR TITLE
fix(button): fixed bug where loading spinner didn't show

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -387,7 +387,7 @@ export const Button: React.FC<ButtonProps> = React.forwardRef(
       >
         {hasAdornment && (
           <LeftAdornment size={size} isSquare={isSquare}>
-            {leftAdornment || <Spinner size={loadingIconSize} />}
+            {loading ? <Spinner size={loadingIconSize} /> : leftAdornment}
           </LeftAdornment>
         )}
         {children}


### PR DESCRIPTION
# Description
Fixed bug where loading spinner didn't show when an adornment was already added to a button