### PR TITLE
Add CardCarousel component

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -34,6 +34,7 @@ export interface CardPropTypes {
   topLeftAdornment?: React.ReactNode
   verticalAlign?: CardVerticalAlign
   size?: CardSize
+  footer?: React.ReactNode
 }
 
 export interface StyledCardProps extends CardPropTypes {
@@ -287,6 +288,10 @@ const Description = styled.div<StyledCardProps>`
   }
 `
 
+const Footer = styled.div`
+  margin-top: ${space[24]};
+`
+
 const Card: React.FC<CardPropTypes> = ({
   title,
   subtitle,
@@ -296,6 +301,7 @@ const Card: React.FC<CardPropTypes> = ({
   leftAdornment,
   rightAdornment,
   topLeftAdornment,
+  footer,
   verticalAlign = CardVerticalAlign.center,
   size = CardSize.default,
   ...props
@@ -328,6 +334,8 @@ const Card: React.FC<CardPropTypes> = ({
 
           {rightAdornment && <RightAdornment>{rightAdornment}</RightAdornment>}
         </Body>
+
+        {footer && <Footer>{footer}</Footer>}
       </Content>
     </Container>
   )

--- a/src/components/CardCarousel/index.stories.tsx
+++ b/src/components/CardCarousel/index.stories.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { CardCarousel } from '.'
+import { H1 } from '../Heading'
+import { Card } from '../Card'
+import styled from '@emotion/styled'
+import { color, space } from '../../theme'
+import { Avatar } from '@ticketswap/comets'
+
+const cards = [
+  {
+    text: 'It’s really helpful to have a personal contact.',
+    author: 'Glenn Gijsberts',
+  },
+  {
+    text: 'I like how the tool is working.',
+    author: 'Rob Vermeer',
+  },
+  {
+    text: 'I do not like this service at all!',
+    author: 'Ronald Tol',
+  },
+  {
+    text: 'The design looks great!',
+    author: 'Jelle Doe',
+  },
+]
+
+const StyledCard = styled(Card)`
+  background-color: ${color.nova};
+  min-width: 320px;
+
+  &:hover,
+  &:focus {
+    background-color: ${color.nova};
+  }
+`
+
+const Container = styled.div`
+  padding: ${space[32]};
+  background-color: ${color.stardustLight};
+`
+
+const Author = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${space[8]};
+`
+
+const Basic = () => (
+  <Container>
+    <CardCarousel
+      leftHeader={<H1>What other says</H1>}
+      cards={cards.map((card, index) => (
+        <StyledCard
+          key={index}
+          text={card.text}
+          footer={
+            <Author>
+              <Avatar
+                src="https://cdn.ticketswap.com/public/testimonials/201810/0946ce7a-5863-4f9f-9636-5ba8bb8414c3.jpeg"
+                alt={`Avatar of ${card.author}`}
+              />
+              <p>{card.author}</p>
+            </Author>
+          }
+        />
+      ))}
+    />
+  </Container>
+)
+
+export { Basic }
+
+export default {
+  title: 'CardCarousel',
+}

--- a/src/components/CardCarousel/index.tsx
+++ b/src/components/CardCarousel/index.tsx
@@ -1,0 +1,132 @@
+import styled from '@emotion/styled'
+import React, { useState } from 'react'
+import { color, space, device, radius } from '../../theme'
+import { ChevronLeft, ChevronRight } from '@ticketswap/comets'
+
+export interface CardCarouselProps {
+  cards: Array<React.ReactNode>
+  leftHeader: React.ReactNode
+  rightHeader?: React.ReactNode
+}
+
+const Carousel = styled.div``
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${space[16]};
+
+  @media ${device.tablet} {
+    margin-bottom: ${space[32]};
+  }
+`
+
+const Controls = styled.div`
+  display: none;
+
+  @media ${device.tablet} {
+    display: flex;
+    gap: ${space[8]};
+  }
+`
+
+const Control = styled.button`
+  background-color: ${color.skyLight};
+  width: 56px;
+  height: 56px;
+  border-radius: ${radius.md};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &:disabled {
+    background-color: ${color.stardustLighter};
+    cursor: default;
+  }
+`
+
+interface CardsProps {
+  index: number
+}
+
+const Cards = styled.div<CardsProps>`
+  display: flex;
+  overflow: scroll;
+  padding: ${space[16]};
+  margin: -${space[16]};
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  gap: ${space[16]};
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media ${device.tablet} {
+    padding: unset;
+    margin: unset;
+    overflow: unset;
+
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+
+    > div {
+      display: none;
+    }
+
+    > div:nth-of-type(${props => props.index}) {
+      display: block;
+      width: 100%;
+    }
+
+    > div:nth-of-type(${props => props.index + 1}) {
+      display: block;
+      width: 100%;
+    }
+  }
+`
+
+export const CardCarousel: React.FC<CardCarouselProps> = ({
+  leftHeader,
+  rightHeader,
+  cards,
+  ...props
+}) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const handleNext = () => setActiveIndex(activeIndex + 1)
+  const handlePrevious = () => setActiveIndex(activeIndex - 1)
+  const nextDisabled = activeIndex >= cards.length - 2
+  const previousDisabled = activeIndex === 0
+
+  return (
+    <Carousel {...props}>
+      <Header>
+        <>
+          <div>{leftHeader}</div>
+
+          {rightHeader ? (
+            rightHeader
+          ) : (
+            <Controls>
+              <Control onClick={handlePrevious} disabled={previousDisabled}>
+                <ChevronLeft
+                  color={false ? color.spaceLightest : color.earth}
+                  size={18}
+                />
+              </Control>
+              <Control onClick={handleNext} disabled={nextDisabled}>
+                <ChevronRight
+                  color={false ? color.spaceLightest : color.earth}
+                  size={18}
+                />
+              </Control>
+            </Controls>
+          )}
+        </>
+      </Header>
+      <Cards index={activeIndex + 1}>{cards}</Cards>
+    </Carousel>
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { Text, SmallText } from './components/Text'
 export { BaseStyles } from './components/BaseStyles'
 export { StarRating } from './components/StarRating'
 export { Button } from './components/Button'
+export { CardCarousel } from './components/CardCarousel'
 export { Card } from './components/Card'
 export { ContentDialog } from './components/ContentDialog'
 export {


### PR DESCRIPTION
# Description

This PR will introduce a new component called CardCarousel. It makes it possible to display our Card component in a carousel. For now it displays 2 cards at a time on desktop and will display the cards in a horizontal scroll on Mobile. It's almost the same implementation as our current carousel in the main repo.

## Changes

- [x] Added CardCarousel component
- [x] Made it possible to give the Card component a footer (e.g. for testimonials etc)

## How to test

- Checkout this branch
- `$ yarn dev`
- `$ yarn storybook`
- Check it out, verify it's working as expected

## Screenshots

<img width="1684" alt="Screenshot 2021-04-15 at 17 56 47" src="https://user-images.githubusercontent.com/14276144/114900764-771f3300-9e14-11eb-9df5-c9507ec5a19a.png">

