### PR TITLE
feat(select): add right adornment to the select items

### DIFF
--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Select } from './'
 import { MagnifyingGlass } from '@ticketswap/comets'
+import { Flag } from '../Flag'
 
 const items = [
   { value: 'de', name: 'German' },
@@ -38,5 +39,28 @@ export const HideLabel = () => (
     initialSelectedItem={items[1]}
     leftAdornment={<MagnifyingGlass size={24} />}
     hideLabel
+  />
+)
+
+const languages = [
+  { value: 'de', name: 'German', rightAdornment: <Flag countryCode="de" /> },
+  { value: 'it', name: 'Italian', rightAdornment: <Flag countryCode="it" /> },
+  {
+    value: 'nl',
+    name: 'Dutch',
+    rightAdornment: <Flag countryCode="nl" />,
+    leftAdornment: <Flag countryCode="nl" />,
+  },
+]
+
+export const withItemAdornments = () => (
+  <Select
+    items={languages}
+    id="language"
+    label="Language"
+    help="Select a language"
+    onChange={selection => console.log(selection)}
+    initialSelectedItem={items[0]}
+    leftAdornment={<MagnifyingGlass size={24} />}
   />
 )

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -32,6 +32,7 @@ type SelectItem = {
   name: string
   displayName?: string
   leftAdornment?: ReactNode
+  rightAdornment?: ReactNode
 }
 
 export interface SelectProps extends Omit<InputProps, 'onChange'> {
@@ -59,7 +60,12 @@ const StyledInput = styled(Input)`
   }
 `
 const LeftAdornment = styled.span`
-  margin-right: 10px;
+  margin-right: ${space[8]};
+`
+
+const RightAdornment = styled.span`
+  position: absolute;
+  right: ${space[16]};
 `
 
 const SelectContainer = styled.div`
@@ -215,6 +221,10 @@ export const Select: React.FC<SelectProps> = ({
               <LeftAdornment>{item.leftAdornment}</LeftAdornment>
             )}
             {item.name}
+
+            {item.rightAdornment && (
+              <RightAdornment>{item.rightAdornment}</RightAdornment>
+            )}
           </InputMenuItem>
         ))}
       </InputMenuList>


### PR DESCRIPTION
# Description

This PR will add the possibility to add a right adornment to the items of a select input. Added story in storybook to display the feature.

## How to test

- Checkout this branch
- `yarn storybook`
- See Select stories
