### PR TITLE
Make it possible to remove the inset shadow of the cover component

### DIFF
--- a/src/components/Cover/index.stories.tsx
+++ b/src/components/Cover/index.stories.tsx
@@ -68,6 +68,18 @@ export const fullHeight = () => (
 
 fullHeight.storyName = 'Full height'
 
+export const withoutInsetShadow = () => (
+  <Cover
+    fullHeight
+    caption={data.randomBackgroundImage.copyrightText}
+    captionUrl={data.randomBackgroundImage.copyrightLink}
+    images={data.randomBackgroundImage.imageSizes}
+    withInsetShadow={false}
+  >
+    <Title>The safest way to buy and sell e-tickets</Title>
+  </Cover>
+)
+
 export const withoutImage = () => (
   <Cover fullHeight>
     <Title>The safest way to buy and sell e-tickets</Title>

--- a/src/components/Cover/index.tsx
+++ b/src/components/Cover/index.tsx
@@ -24,17 +24,22 @@ export interface CoverProps {
   captionUrl?: string
   blurred?: boolean
   fullHeight?: boolean
+  withInsetShadow?: boolean
 }
 
 const Container = styled.div<CoverProps>`
   position: relative;
-  background-color: ${color.space};
   width: 100%;
   height: ${props => (props.fullHeight ? '100vh' : 'auto')};
 
-  [data-theme='dark'] & {
-    background-color: ${color.nova};
-  }
+  ${props =>
+    props.withInsetShadow &&
+    css`
+      background-color: ${color.space};
+      [data-theme='dark'] & {
+        background-color: ${color.nova};
+      }
+    `}
 
   ${props =>
     props.blurred &&
@@ -48,9 +53,15 @@ const BackgroundImage = styled.div<CoverProps>`
   left: 0;
   top: 0;
   right: 0;
-  height: 75%;
+  height: 100%;
   background-size: cover;
   background-position: center;
+
+  ${props =>
+    props.withInsetShadow &&
+    css`
+      height: 75%;
+    `}
 
   ${props =>
     props.blurred &&
@@ -150,39 +161,57 @@ const BackgroundImage = styled.div<CoverProps>`
     height: 75%;
     background-image: linear-gradient(
       to top,
-      rgba(0, 19, 25, 1) 0%,
-      rgba(0, 19, 25, 0.738) 19%,
-      rgba(0, 19, 25, 0.541) 34%,
-      rgba(0, 19, 25, 0.382) 47%,
-      rgba(0, 19, 25, 0.278) 56.5%,
-      rgba(0, 19, 25, 0.194) 65%,
-      rgba(0, 19, 25, 0.126) 73%,
-      rgba(0, 19, 25, 0.075) 80.2%,
-      rgba(0, 19, 25, 0.042) 86.1%,
-      rgba(0, 19, 25, 0.021) 91%,
-      rgba(0, 19, 25, 0.008) 95.2%,
-      rgba(0, 19, 25, 0.002) 98.2%,
+      rgba(0, 19, 25, 0.6) 0%,
       rgba(0, 19, 25, 0) 100%
     );
 
     [data-theme='dark'] & {
       background-image: linear-gradient(
         to top,
-        rgba(26, 33, 41, 1) 0%,
-        rgba(26, 33, 41, 0.738) 19%,
-        rgba(26, 33, 41, 0.541) 34%,
-        rgba(26, 33, 41, 0.382) 47%,
-        rgba(26, 33, 41, 0.278) 56.5%,
-        rgba(26, 33, 41, 0.194) 65%,
-        rgba(26, 33, 41, 0.126) 73%,
-        rgba(26, 33, 41, 0.075) 80.2%,
-        rgba(26, 33, 41, 0.042) 86.1%,
-        rgba(26, 33, 41, 0.021) 91%,
-        rgba(26, 33, 41, 0.008) 95.2%,
-        rgba(26, 33, 41, 0.002) 98.2%,
+        rgba(26, 33, 41, 0.6) 0%,
         rgba(26, 33, 41, 0) 100%
       );
     }
+
+    ${props =>
+      props.withInsetShadow &&
+      css`
+        background-image: linear-gradient(
+          to top,
+          rgba(0, 19, 25, 1) 0%,
+          rgba(0, 19, 25, 0.738) 19%,
+          rgba(0, 19, 25, 0.541) 34%,
+          rgba(0, 19, 25, 0.382) 47%,
+          rgba(0, 19, 25, 0.278) 56.5%,
+          rgba(0, 19, 25, 0.194) 65%,
+          rgba(0, 19, 25, 0.126) 73%,
+          rgba(0, 19, 25, 0.075) 80.2%,
+          rgba(0, 19, 25, 0.042) 86.1%,
+          rgba(0, 19, 25, 0.021) 91%,
+          rgba(0, 19, 25, 0.008) 95.2%,
+          rgba(0, 19, 25, 0.002) 98.2%,
+          rgba(0, 19, 25, 0) 100%
+        );
+
+        [data-theme='dark'] & {
+          background-image: linear-gradient(
+            to top,
+            rgba(26, 33, 41, 1) 0%,
+            rgba(26, 33, 41, 0.738) 19%,
+            rgba(26, 33, 41, 0.541) 34%,
+            rgba(26, 33, 41, 0.382) 47%,
+            rgba(26, 33, 41, 0.278) 56.5%,
+            rgba(26, 33, 41, 0.194) 65%,
+            rgba(26, 33, 41, 0.126) 73%,
+            rgba(26, 33, 41, 0.075) 80.2%,
+            rgba(26, 33, 41, 0.042) 86.1%,
+            rgba(26, 33, 41, 0.021) 91%,
+            rgba(26, 33, 41, 0.008) 95.2%,
+            rgba(26, 33, 41, 0.002) 98.2%,
+            rgba(26, 33, 41, 0) 100%
+          );
+        }
+      `};
   }
 `
 
@@ -256,17 +285,24 @@ export const Cover: React.FC<CoverProps> = ({
   images,
   blurred = false,
   fullHeight = false,
+  withInsetShadow = true,
   ...props
 }) => {
   const hasImages = imageUrl || images
 
   return (
-    <Container fullHeight={fullHeight} blurred={blurred} {...props}>
+    <Container
+      fullHeight={fullHeight}
+      blurred={blurred}
+      withInsetShadow={withInsetShadow}
+      {...props}
+    >
       {hasImages && (
         <BackgroundImage
           imageUrl={imageUrl}
           images={images}
           blurred={blurred}
+          withInsetShadow={withInsetShadow}
         />
       )}
 


### PR DESCRIPTION
# Description

This PR will make it possible to remove the inset shadow of the cover component. It will introduce a `withInsetShadow` property that's defaulted to `true`. If you turn it off you will still have a really little shadow to make sure that content that is on top of the cover is still a bit visible.

## How to test

- Checkout this branch
- yarn storybook
- Checkout the new added story

## Screenshots

<img width="1632" alt="Screenshot 2021-05-21 at 13 21 53" src="https://user-images.githubusercontent.com/14276144/119129903-d4238f80-ba37-11eb-8aef-f3bbfb10f4d3.png">
<img width="1644" alt="Screenshot 2021-05-21 at 13 21 39" src="https://user-images.githubusercontent.com/14276144/119129930-d980da00-ba37-11eb-833b-26afe347ae4a.png">
