### PR TITLE
fix(cover): fix withInsetShadow for dark mode

### DIFF
--- a/src/components/Cover/index.tsx
+++ b/src/components/Cover/index.tsx
@@ -165,14 +165,6 @@ const BackgroundImage = styled.div<CoverProps>`
       rgba(0, 19, 25, 0) 100%
     );
 
-    [data-theme='dark'] & {
-      background-image: linear-gradient(
-        to top,
-        rgba(26, 33, 41, 0.6) 0%,
-        rgba(26, 33, 41, 0) 100%
-      );
-    }
-
     ${props =>
       props.withInsetShadow &&
       css`
@@ -192,8 +184,18 @@ const BackgroundImage = styled.div<CoverProps>`
           rgba(0, 19, 25, 0.002) 98.2%,
           rgba(0, 19, 25, 0) 100%
         );
+      `};
 
-        [data-theme='dark'] & {
+    [data-theme='dark'] & {
+      background-image: linear-gradient(
+        to top,
+        rgba(26, 33, 41, 0.6) 0%,
+        rgba(26, 33, 41, 0) 100%
+      );
+
+      ${props =>
+        props.withInsetShadow &&
+        css`
           background-image: linear-gradient(
             to top,
             rgba(26, 33, 41, 1) 0%,
@@ -210,8 +212,8 @@ const BackgroundImage = styled.div<CoverProps>`
             rgba(26, 33, 41, 0.002) 98.2%,
             rgba(26, 33, 41, 0) 100%
           );
-        }
-      `};
+        `};
+    }
   }
 `
 


### PR DESCRIPTION
# Description

The shadow of the withInsetShadow property was not properly set for dark mode, resulting in a style bug for dark mode.

<img width="1667" alt="Screenshot 2021-05-21 at 14 24 50" src="https://user-images.githubusercontent.com/14276144/119136722-50ba6c00-ba40-11eb-9eb0-351df6f75f9e.png">
