### PR TITLE
fix(Input): Make sure to hide the arrows in numbers input

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -100,6 +100,10 @@ export const fieldStyles = (props: InputProps) => css`
     display: none;
   }
 
+  &[type='number'] {
+    -moz-appearance: textfield;
+  }
+
   &:focus,
   &.focus {
     outline: none;


### PR DESCRIPTION
# Description

We were already doing this for almost every browser but firefox. This will make sure we hide it for firefox browser as well.


## How to test

- Checkout
- yarn storybook
- verify the money input is not showing any arrows in firefox

## Screenshots
before
<img width="1680" alt="Screenshot 2021-06-29 at 17 32 10" src="https://user-images.githubusercontent.com/14276144/123826944-8173a800-d900-11eb-9a33-e56a9a7e212a.png">

after
<img width="1678" alt="Screenshot 2021-06-29 at 17 32 20" src="https://user-images.githubusercontent.com/14276144/123826937-80427b00-d900-11eb-8e4a-8f15675022aa.png">

