### PR TITLE
chore(storybook): fix compile error due to latest typescript update

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
   addons: [],
   typescript: {
     check: true, // type-check stories during Storybook build
+    reactDocgen: 'none',
   },
   webpackFinal: async config => {
     return {


### PR DESCRIPTION
# Description
The latest typescript version is using a 3rd party script that's having some type errors. More info
here https://github.com/styleguidist/react-docgen-typescript/issues/356

## How to test

- Checkout
- `yarn`
- `yarn storybook`
- Verify that storybook is running without any problems 
