### PR TITLE
feat(moneyinput): support for maximumAmount

### DIFF
--- a/src/components/MoneyInput/index.stories.tsx
+++ b/src/components/MoneyInput/index.stories.tsx
@@ -190,3 +190,18 @@ export const WithError = () => (
 )
 
 WithError.storyName = 'With error'
+
+export const WithMaximumValue = () => (
+  <MoneyInput
+    id="maximum-price"
+    label="Maximum price"
+    currencies={currencies}
+    onChange={e => console.log(e)}
+    initialSelectedCurrency={currencies[2]}
+    initialAmount={2500}
+    maximumAmount={3000}
+    help="The maximum amount is 30"
+  />
+)
+
+WithMaximumValue.storyName = 'With maximum value'


### PR DESCRIPTION
# Description

In order to make it possible to maximize the amount that can be entered in a money field a new
property was added to configure a maximum amount.

## How to test

- Open the storybook
- Goto `With maximum amount` under the `MoneyInput`
- Try to enter a amount bigger then `30`
- Verify other stories related to `MoneyInput` still work as expected
- Verify it works as expected
- Order pizza to celebrate 🍕 

## Screenshots

<img width="413" alt="image" src="https://user-images.githubusercontent.com/1238070/134653890-9883bdb8-85e0-4d1f-929e-badd701302a1.png">