### PR TITLE
fix(moneyinput): Safari wouldn't accept decimal numbers

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -28,6 +28,7 @@ export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   rightAdornment?: ReactNode
   value?: number | string
   type?: string
+  step?: string
   onChange?: React.FormEventHandler<HTMLInputElement>
   menu?: boolean | object
   validate?: boolean

--- a/src/components/MoneyInput/index.stories.tsx
+++ b/src/components/MoneyInput/index.stories.tsx
@@ -144,6 +144,20 @@ export const Basic = () => (
   />
 )
 
+export const BasicForm = () => (
+  <form>
+    <MoneyInput
+      id="maximum-price"
+      label="Maximum price"
+      currencies={currencies}
+      onChange={e => console.log(e)}
+    />
+    <button type="submit">Save</button>
+  </form>
+)
+
+BasicForm.storyName = 'With form'
+
 export const WithInitialValues = () => (
   <MoneyInput
     id="maximum-price"

--- a/src/components/MoneyInput/index.tsx
+++ b/src/components/MoneyInput/index.tsx
@@ -186,6 +186,7 @@ export const MoneyInput: React.FC<MoneyInputProps> = ({
             ref={inputRef}
             hideLabel
             type="number"
+            step="0.01"
             value={isAmountControlled ? props.amount : amount}
             disabled={disabled}
             validate={validateAmount}


### PR DESCRIPTION
# Description
The default step value in a input where the type is number on safari is `1`
This is why safari wouldn't accept float values, but only integers.

## Changes
- Added step of 0.01 to the moneyInput

## How to test
In safari go to storybook `MoneyInput > with form` and try adding a decimal value and click save.
