### PR TITLE
feat(cover): make it possible to style cover content

### DIFF
--- a/src/components/Cover/index.tsx
+++ b/src/components/Cover/index.tsx
@@ -217,13 +217,13 @@ const BackgroundImage = styled.div<CoverProps>`
   }
 `
 
-const Content = styled.div<CoverProps>`
+const Content = styled.section<CoverProps>`
   position: relative;
   padding-top: ${props => (props.blurred ? `${space[64]}` : `${space[128]}`)};
   padding-bottom: ${space[24]};
 
   @media ${device.tablet} {
-    padding-top: ${144 / 16}rem;
+    padding-top: ${space[144]};
     padding-bottom: ${space[48]};
   }
 `

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -111,6 +111,7 @@ export const space = {
   88: '5.5rem',
   96: '6rem',
   128: '8rem',
+  144: '9rem',
   256: '16rem',
   512: '32rem',
   768: '48rem',


### PR DESCRIPTION
# Description

Before it was a div, so it was pretty hard to style the content of the cover, since there are more divs in the cover, even a div sibling for the cover content. By making the content more semantic it's also easier to style this now.
