### PR TITLE
fix(Accordion): Align text in accordion button to the left

### DIFF
--- a/src/components/Accordion/index.stories.tsx
+++ b/src/components/Accordion/index.stories.tsx
@@ -13,8 +13,7 @@ export const Basic = () => (
       <AccordionPanel>
         <p>
           Here are some detailed instructions about doing a thing. I am very
-          complex and probably contain a lot of content, so a user can hide or
-          show me by clicking the button above.
+          complex.
         </p>
       </AccordionPanel>
     </AccordionItem>
@@ -26,6 +25,17 @@ export const Basic = () => (
           There are a lot of things someone might want to do, so I am only going
           to talk about doing that other thing. I'll let my fellow accordion
           items go into detail about even more things.
+        </p>
+      </AccordionPanel>
+    </AccordionItem>
+    <AccordionItem>
+      <AccordionButton>Click here to see a super long text</AccordionButton>
+      <AccordionPanel>
+        <p>
+          Kidding. Here are some detailed instructions about doing yet another
+          thing. There are a lot of things someone might want to do, so I am
+          only going to talk about doing that other thing. I'll let my fellow
+          accordion items go into detail about even more things.
         </p>
       </AccordionPanel>
     </AccordionItem>

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -49,6 +49,7 @@ const Button = styled<React.FC<AccordionButtonProps>>(Reach.AccordionButton)`
   justify-content: space-between;
   padding-top: ${space[12]};
   padding-bottom: ${space[12]};
+  text-align: left;
 
   &[data-disabled] {
     cursor: not-allowed;


### PR DESCRIPTION
# Description

This will fix https://github.com/TicketSwap/solar/issues/1048.

## How to test

- Checkout this branch
- yarn
- yarn storybook
- Verify the last story of Accordion is working as expected

## Screenshots

Old
<img width="1367" alt="Screenshot 2021-10-28 at 15 42 46" src="https://user-images.githubusercontent.com/14276144/139268931-b32b39c2-b801-415d-aec1-ce35cb67cca6.png">

New
<img width="686" alt="Screenshot 2021-10-28 at 15 42 31" src="https://user-images.githubusercontent.com/14276144/139268980-0c9eb9c6-cfd8-4c22-9181-ec21772e8e73.png">

