### PR TITLE
feat(Button): Add google variant

### DIFF
--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -14,6 +14,7 @@ const VARIANTS = [
   ButtonVariant.facebook,
   ButtonVariant.inverted,
   ButtonVariant.apple,
+  ButtonVariant.google,
 ]
 
 const PresentationalWrapper = styled.div`

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -22,6 +22,7 @@ export enum ButtonVariant {
   facebook = 'facebook',
   inverted = 'inverted',
   apple = 'apple',
+  google = 'google',
 }
 
 export enum ButtonSize {
@@ -336,6 +337,39 @@ const StyledButton = styled.button<StyledButtonProps>`
 
       &:active {
         background-color: ${color.spaceDark};
+      }
+    `};
+
+  ${({ variant }) =>
+    variant === ButtonVariant.google &&
+    css`
+      background-color: ${color.nova};
+      color: ${color.spaceMedium};
+      border: 1px solid ${color.spaceLightest};
+      background-image: unset;
+
+      &:hover {
+        background-color: ${color.spaceLightest};
+      }
+
+      &:focus::after {
+        box-shadow: 0 0 0 ${space[4]} ${color.spaceLighterAlpha};
+      }
+
+      &:active {
+        background-color: ${color.spaceLightest};
+      }
+
+      [data-theme='dark'] & {
+        background-color: ${color.space};
+        color: ${color.spaceLighter};
+
+        &:hover {
+          background-color: ${color.spaceDark};
+        }
+        &:active {
+          background-color: ${color.spaceDark};
+        }
       }
     `};
 `


### PR DESCRIPTION
# Description

Adds a button variant that's inspired by the google login button.


![btn_google_signin_light_normal_web@2x](https://user-images.githubusercontent.com/14276144/140080089-0c893d61-96c2-4bc4-a367-b13a8d301e34.png)

![Screenshot 2021-11-03 at 15 31 55](https://user-images.githubusercontent.com/14276144/140080151-cc511dc8-3177-4d83-8f68-7058b27076db.png)

