### PR TITLE
Improve Select rendering of mobile version

### DIFF
--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { screen, render, fireEvent } from '@testing-library/react'
 import { Select } from '.'
+import * as useDeviceInfo from '../../hooks/useDeviceInfo'
+
+jest.mock('../../hooks/useDeviceInfo')
 
 const languages = [
   { value: 'de', name: 'German' },
@@ -13,86 +16,154 @@ const languages = [
 ]
 
 describe('Select', () => {
-  it('renders without crashing and has menu closed intially', () => {
-    const { container, queryByText } = render(
-      <Select id="language" label="Language" items={languages} />
-    )
-    expect(container.firstChild).toBeInTheDocument()
-    expect(queryByText(/italian/i)).toBeNull()
-  })
-
-  it('value equals first item', () => {
-    const { getByLabelText } = render(
-      <Select id="language" label="Language" items={languages} />
-    )
-
-    const input = getByLabelText(/language/i) as HTMLInputElement
-    expect(input.value).toEqual(languages[0].name)
-  })
-
-  describe('when the select box is clicked', () => {
-    it('shows the dropdown', () => {
-      render(<Select id="language" label="Language" items={languages} />)
-
-      fireEvent.focus(screen.getByLabelText(/language/i))
-
-      expect(screen.getByText(/italian/i)).toBeInTheDocument()
+  describe('when the component is rendered on mobile', () => {
+    beforeAll(() => {
+      jest.spyOn(useDeviceInfo, 'useDeviceInfo').mockImplementation(() => ({
+        isMobile: () => true,
+        isIOS: () => true,
+        isDesktop: () => false,
+        isAndroid: () => false,
+      }))
     })
 
-    describe('and a key is a pressed', () => {
-      it('highlights the correct option', () => {
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it('renders a native select box', async () => {
+      render(
+        <Select
+          id="language"
+          label="Language"
+          items={languages}
+          onChange={() => {}}
+        />
+      )
+
+      expect(
+        screen.queryByRole('textbox', { name: /language arrowdown/i })
+      ).not.toBeInTheDocument()
+
+      expect(
+        screen.getByRole('combobox', { name: /language/i })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('when the component is rendered on any other device', () => {
+    beforeAll(() => {
+      jest.spyOn(useDeviceInfo, 'useDeviceInfo').mockImplementation(() => ({
+        isDesktop: () => true,
+        isMobile: () => false,
+        isAndroid: () => false,
+        isIOS: () => false,
+      }))
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it('renders a custom select box', async () => {
+      render(
+        <Select
+          id="language"
+          label="Language"
+          items={languages}
+          onChange={() => {}}
+        />
+      )
+
+      expect(
+        screen.queryByRole('combobox', { name: /language/i })
+      ).not.toBeInTheDocument()
+
+      expect(
+        screen.getByRole('textbox', { name: /language arrowdown/i })
+      ).toBeInTheDocument()
+    })
+
+    it('renders without crashing and has menu closed initially', () => {
+      const { container, queryByText } = render(
+        <Select id="language" label="Language" items={languages} />
+      )
+      expect(container.firstChild).toBeInTheDocument()
+      expect(queryByText(/italian/i)).toBeNull()
+    })
+
+    it('value equals first item', () => {
+      const { getByLabelText } = render(
+        <Select id="language" label="Language" items={languages} />
+      )
+
+      const input = getByLabelText(/language/i) as HTMLInputElement
+      expect(input.value).toEqual(languages[0].name)
+    })
+
+    describe('when the select box is clicked', () => {
+      it('shows the dropdown', () => {
         render(<Select id="language" label="Language" items={languages} />)
 
         fireEvent.focus(screen.getByLabelText(/language/i))
 
-        fireEvent.keyDown(screen.getByRole('textbox'), {
-          key: 'D',
-          code: 'D',
-          charCode: 68,
-        })
+        expect(screen.getByText(/italian/i)).toBeInTheDocument()
+      })
 
-        fireEvent.keyDown(screen.getByRole('textbox'), {
-          key: 'U',
-          code: 'U',
-          charCode: 85,
-        })
+      describe('and a key is a pressed', () => {
+        it('highlights the correct option', () => {
+          render(<Select id="language" label="Language" items={languages} />)
 
-        expect(screen.getByText(/Dutch/i)).toHaveAttribute(
-          'data-highlighted',
-          '2'
-        )
+          fireEvent.focus(screen.getByLabelText(/language/i))
+
+          fireEvent.keyDown(screen.getByRole('textbox'), {
+            key: 'D',
+            code: 'D',
+            charCode: 68,
+          })
+
+          fireEvent.keyDown(screen.getByRole('textbox'), {
+            key: 'U',
+            code: 'U',
+            charCode: 85,
+          })
+
+          expect(screen.getByText(/Dutch/i)).toHaveAttribute(
+            'data-highlighted',
+            '2'
+          )
+        })
       })
     })
-  })
 
-  it('handles a passed initial value correctly', async () => {
-    const { getByLabelText } = render(
-      <Select
-        id="language"
-        label="Language"
-        items={languages}
-        initialSelectedItem={languages[1]}
-      />
-    )
-    const input = getByLabelText(/language/i) as HTMLInputElement
+    it('handles a passed initial value correctly', async () => {
+      const { getByLabelText } = render(
+        <Select
+          id="language"
+          label="Language"
+          items={languages}
+          initialSelectedItem={languages[1]}
+        />
+      )
+      const input = getByLabelText(/language/i) as HTMLInputElement
 
-    expect(input.value).toEqual(languages[1].name)
-  })
+      expect(input.value).toEqual(languages[1].name)
+    })
 
-  it('calls onChange handler correctly and closes menu on item click', () => {
-    const handler = jest.fn()
-    const { getByText, getByLabelText, queryByText } = render(
-      <Select
-        id="language"
-        label="Language"
-        items={languages}
-        onChange={selection => handler(selection)}
-      />
-    )
-    fireEvent.focus(getByLabelText(/language/i))
-    fireEvent.mouseDown(getByText(/dutch/i))
-    expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(languages[2])
-    expect(queryByText(/italian/i)).toBeNull()
+    it('calls onChange handler correctly and closes menu on item click', () => {
+      const handler = jest.fn()
+      const { getByText, getByLabelText, queryByText } = render(
+        <Select
+          id="language"
+          label="Language"
+          items={languages}
+          onChange={selection => handler(selection)}
+        />
+      )
+      fireEvent.focus(getByLabelText(/language/i))
+      fireEvent.mouseDown(getByText(/dutch/i))
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler).toHaveBeenCalledWith(languages[2])
+      expect(queryByText(/italian/i)).toBeNull()
+    })
   })
 })

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -125,7 +125,6 @@ export const Select: FC<SelectProps> = ({
   ...props
 }) => {
   const { isMobile } = useDeviceInfo()
-  const [showCustomSelect, setShowCustomSelect] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [selectedItem, setSelectedItem] = useState(
@@ -161,16 +160,6 @@ export const Select: FC<SelectProps> = ({
   function setItemRef(el: HTMLLIElement) {
     return (itemRefs = [...itemRefs, el])
   }
-
-  useEffect(() => {
-    if (!isMobile()) {
-      // Component will render a native select element by default.
-      // Upon mounting, we check whether we’re on a mobile device. If
-      // not, render the custom select.
-      setShowCustomSelect(true)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   useEffect(() => {
     // Select is controlled
@@ -215,40 +204,6 @@ export const Select: FC<SelectProps> = ({
     }
   }, [arrowUp, arrowDown, scrollHighlightedItemIntoView])
 
-  const menu = isOpen && (
-    <SelectMenu tabIndex={-1} role="listbox" aria-labelledby={labelId}>
-      <InputMenuList id={menuId} ref={menuRef}>
-        {items.map((item, index) => (
-          <InputMenuItem
-            id={`${id}-item-${item.value}`}
-            key={item.value}
-            role="option"
-            ref={setItemRef}
-            selected={selectedItem.value === item.value}
-            highlighted={highlightedIndex === index}
-            onMouseMove={() => setHighlightedIndex(index)}
-            onMouseDown={() => {
-              onChange(item)
-              setSelectedItem(item)
-              handleClose()
-            }}
-            aria-selected={selectedItem === item ? 'true' : 'false'}
-            data-highlighted={highlightedIndex}
-          >
-            {item.leftAdornment && (
-              <LeftAdornment>{item.leftAdornment}</LeftAdornment>
-            )}
-            {item.name}
-
-            {item.rightAdornment && (
-              <RightAdornment>{item.rightAdornment}</RightAdornment>
-            )}
-          </InputMenuItem>
-        ))}
-      </InputMenuList>
-    </SelectMenu>
-  )
-
   const handleKeyDown = (e: KeyboardEvent) => {
     if (!isOpen) return false
 
@@ -290,9 +245,43 @@ export const Select: FC<SelectProps> = ({
     }
   }
 
-  return (
-    <Container ref={containerRef}>
-      {!showCustomSelect && (
+  const menu = isOpen && (
+    <SelectMenu tabIndex={-1} role="listbox" aria-labelledby={labelId}>
+      <InputMenuList id={menuId} ref={menuRef}>
+        {items.map((item, index) => (
+          <InputMenuItem
+            id={`${id}-item-${item.value}`}
+            key={item.value}
+            role="option"
+            ref={setItemRef}
+            selected={selectedItem.value === item.value}
+            highlighted={highlightedIndex === index}
+            onMouseMove={() => setHighlightedIndex(index)}
+            onMouseDown={() => {
+              onChange(item)
+              setSelectedItem(item)
+              handleClose()
+            }}
+            aria-selected={selectedItem === item ? 'true' : 'false'}
+            data-highlighted={highlightedIndex}
+          >
+            {item.leftAdornment && (
+              <LeftAdornment>{item.leftAdornment}</LeftAdornment>
+            )}
+            {item.name}
+
+            {item.rightAdornment && (
+              <RightAdornment>{item.rightAdornment}</RightAdornment>
+            )}
+          </InputMenuItem>
+        ))}
+      </InputMenuList>
+    </SelectMenu>
+  )
+
+  if (isMobile()) {
+    return (
+      <Container ref={containerRef}>
         <SelectContainer {...props}>
           {props.hideLabel ? (
             <VisuallyHidden>
@@ -334,34 +323,34 @@ export const Select: FC<SelectProps> = ({
 
           {props.help && <Help>{props.help}</Help>}
         </SelectContainer>
-      )}
+      </Container>
+    )
+  }
 
-      {showCustomSelect && (
-        <>
-          <StyledInput
-            {...props}
-            id={id}
-            ref={inputRef}
-            label={label}
-            value={selectedItem.displayName || selectedItem.name}
-            // @ts-ignore readOnly is not in the types
-            readOnly
-            labelProps={{ id: labelId, htmlFor: id }}
-            onFocus={() => setIsOpen(true)}
-            onBlur={() => setIsOpen(false)}
-            rightAdornment={<ArrowDown size={16} />}
-            leftAdornment={leftAdornment}
-            onKeyDown={handleKeyDown}
-            aria-haspopup="listbox"
-            aria-labelledby={labelId}
-            aria-controls={menuId}
-            aria-activedescendant={`${id}-item-${selectedItem.value}`}
-            menu={!floatingMenu && menu}
-          />
+  return (
+    <Container ref={containerRef}>
+      <StyledInput
+        {...props}
+        id={id}
+        ref={inputRef}
+        label={label}
+        value={selectedItem.displayName || selectedItem.name}
+        // @ts-ignore readOnly is not in the types
+        readOnly
+        labelProps={{ id: labelId, htmlFor: id }}
+        onFocus={() => setIsOpen(true)}
+        onBlur={() => setIsOpen(false)}
+        rightAdornment={<ArrowDown size={16} />}
+        leftAdornment={leftAdornment}
+        onKeyDown={handleKeyDown}
+        aria-haspopup="listbox"
+        aria-labelledby={labelId}
+        aria-controls={menuId}
+        aria-activedescendant={`${id}-item-${selectedItem.value}`}
+        menu={!floatingMenu && menu}
+      />
 
-          {floatingMenu && menu}
-        </>
-      )}
+      {floatingMenu && menu}
     </Container>
   )
 }


### PR DESCRIPTION
# Description

We were using a `useEffect` to change the type of select box that is rendered (a custom one or a native one for mobile).

The split between one or the other should be done right on the first render, instead of waiting for the component to mount, otherwise, users might see the custom one for a split second (also, we were rendering the custom one without the need on the first render on mobile).

Tests for the rendering of a different component depending on the device used are also introduced.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn storybook`
- Check the Select component and experiment with different devices
- You can also compile the project and move the output to your own project using Solar and test it there
 
## Screenshots
https://user-images.githubusercontent.com/1096800/140517862-2cec2335-780d-4751-b08b-ed6956d16af3.mov


## To be notified
@TicketSwap/frontend 

## Links
Fixes #1243 