### PR TITLE
Cleanup of `HorizontalScroll` Component

### DIFF
--- a/src/components/HorizontalScroll/index.tsx
+++ b/src/components/HorizontalScroll/index.tsx
@@ -4,15 +4,11 @@ import { space, device } from '../../theme'
 export const HorizontalScroll = styled.div`
   position: relative;
   overflow-x: scroll;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
   white-space: nowrap;
-  scroll-snap-type: x mandatory;
   scroll-padding: ${space[16]};
   padding-left: ${space[16]};
   padding-right: ${space[16]};
   scrollbar-width: none;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   ::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
# Description
Removed unecessary css from HorizontalScroll Component 

## Changes

I removed unnecessary css that were no longer supported by main browsers anyway. I then tested on safari, firefox and chrome + used browsertsack to try on different mobile devices and browsers.

## How to test
- Make sure the horizontal scroll still works as it should on different browsers 

## Links
#1060