### PR TITLE
Refactor(horizontalscroll): removal of unecessary/deprecated css

### DIFF
--- a/src/components/HorizontalScroll/index.tsx
+++ b/src/components/HorizontalScroll/index.tsx
@@ -4,15 +4,11 @@ import { space, device } from '../../theme'
 export const HorizontalScroll = styled.div`
   position: relative;
   overflow-x: scroll;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
   white-space: nowrap;
-  scroll-snap-type: x mandatory;
   scroll-padding: ${space[16]};
   padding-left: ${space[16]};
   padding-right: ${space[16]};
   scrollbar-width: none;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   ::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
# Description

Cleaned up some of the css that were no longer supported by main browsers and
not useful for the horizontal scroll to work as expected

## Links
Fix #1060
