### PR TITLE
Don't collect test coverage from Storybook stories

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   collectCoverageFrom: [
     '**/src/**/*.(js|jsx|ts|tsx)',
     '!**/*.test.(js|jsx|ts|tsx)',
+    '!**/*.stories.(js|jsx|ts|tsx)',
   ],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
# Description

This PR changes our Jest configuration so that stories are ignored when collecting coverage metrics.

fixes #1252

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout main, run `yarn test:coverage`
- Access the .coverage folder and open index.html in your browser
- Check inside one of the components that *.stories are taken into the calculation

- Check out this branch, run it again, access the same page, and check the stories are no longer taken into account.

## Screenshots

**Our coverage is much higher than we thought 🎉** 

**Before**
<img width="778" alt="Screenshot 2021-11-22 at 15 19 24" src="https://user-images.githubusercontent.com/1096800/142878797-0dde6fdc-6b8f-4af5-b09a-4a08c8b9a12d.png">

**After**
<img width="783" alt="Screenshot 2021-11-22 at 15 19 54" src="https://user-images.githubusercontent.com/1096800/142878811-e9b70bf8-7b90-47ce-abd4-33a2cba6b25c.png">

## To be notified
@TicketSwap/frontend 

## Links
https://jestjs.io/docs/configuration
#1252