### PR TITLE
Make Card component with Subtitle and Text the same font-size

### DIFF
--- a/src/components/Card/index.stories.tsx
+++ b/src/components/Card/index.stories.tsx
@@ -106,6 +106,44 @@ export const WithText = () => (
 
 WithText.storyName = 'With text'
 
+export const WithTextAndSubtitle = () => (
+  <Grid>
+    <a href="/" style={{ minWidth: 0 }}>
+      <Card
+        title="Eurovision Song Contest - 1st Semi Final Jury Show"
+        subtitle="I'm a subtitle"
+        text="Lorem ipsum dolor sit amet."
+        verticalAlign={CardVerticalAlign.top}
+      />
+    </a>
+    <a href="/" style={{ minWidth: 0 }}>
+      <Card
+        title="Eurovision Song Contest - 1st Semi Final Family Show"
+        subtitle="I'm a subtitle"
+        text="Lorem ipsum dolor sit amet."
+        leftAdornment={
+          <Avatar size={44} src="https://www.placecage.com/200/200" />
+        }
+        verticalAlign={CardVerticalAlign.top}
+      />
+    </a>
+    <a href="/" style={{ minWidth: 0 }}>
+      <Card
+        title="Eurovision Song Contest - Grand Final Live Show"
+        subtitle="I'm a subtitle"
+        text="Lorem ipsum dolor sit amet."
+        leftAdornment={
+          <Avatar size={44} src="https://www.placecage.com/200/200" />
+        }
+        rightAdornment={<Pill leftAdornment={<Ticket size={16} />}>25</Pill>}
+        verticalAlign={CardVerticalAlign.top}
+      />
+    </a>
+  </Grid>
+)
+
+WithText.storyName = 'With text and subtitle'
+
 export const WithImage = () => (
   <Grid>
     <a href="/" style={{ minWidth: 0 }}>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -39,6 +39,7 @@ export interface CardPropTypes {
 
 export interface StyledCardProps extends CardPropTypes {
   hasImage?: boolean
+  hasSubtitle?: boolean
 }
 
 const Container = styled.div<StyledCardProps>`
@@ -220,12 +221,23 @@ const Subtitle = styled.h5<StyledCardProps>`
 const Text = styled.span<StyledCardProps>`
   ${props => !props.hasImage && truncate};
   display: block;
-  font-size: ${p => (p.size === CardSize.large ? fontSize[14] : fontSize[12])};
+  font-size: ${p => {
+    if (p.hasSubtitle) {
+      return p.size === CardSize.large ? fontSize[18] : fontSize[16]
+    }
+
+    return p.size === CardSize.large ? fontSize[14] : fontSize[12]
+  }};
   opacity: 0.6;
 
   @media ${device.mobileL} {
-    font-size: ${p =>
-      p.size === CardSize.large ? fontSize[16] : fontSize[14]};
+    font-size: ${p => {
+      if (p.hasSubtitle) {
+        return p.size === CardSize.large ? fontSize[18] : fontSize[16]
+      }
+
+      return p.size === CardSize.large ? fontSize[16] : fontSize[14]
+    }};
   }
 
   ${props =>
@@ -302,6 +314,7 @@ const Card: React.FC<CardPropTypes> = ({
   ...props
 }) => {
   const hasImage = Boolean(image)
+  const hasSubtitle = Boolean(subtitle)
 
   return (
     <Container hasImage={hasImage} {...props}>
@@ -320,9 +333,13 @@ const Card: React.FC<CardPropTypes> = ({
           <TextContent hasImage={hasImage}>
             {title && <Title hasImage={hasImage}>{title}</Title>}
 
-            {subtitle && <Subtitle hasImage={hasImage}>{subtitle}</Subtitle>}
+            {hasSubtitle && <Subtitle hasImage={hasImage}>{subtitle}</Subtitle>}
 
-            {text && <Text hasImage={hasImage}>{text}</Text>}
+            {text && (
+              <Text hasSubtitle={hasSubtitle} hasImage={hasImage}>
+                {text}
+              </Text>
+            )}
 
             {description && (
               <Description hasImage={hasImage}>{description}</Description>


### PR DESCRIPTION
# Description

The Text in the `Card` component currently acts as a kind of sub-subtitle. We want both the `Text` and the `Subtitle` to have the same font-size when they are both defined. There is only one place where this happens in Sirius, which is where we want to define this (the listings inside event-type pages).

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`

## Screenshots
**Before**
<img width="528" alt="Screenshot 2021-11-30 at 18 53 51" src="https://user-images.githubusercontent.com/1096800/144101311-6df38375-1848-4081-8116-c783e2e25dcc.png">

**After**
<img width="534" alt="Screenshot 2021-11-30 at 18 53 19" src="https://user-images.githubusercontent.com/1096800/144101525-3ae9463c-840b-4c70-bb73-5526b17e0b0f.png">

## To be notified
@Marruk 

## Links
[JIRA GIN-1731](https://ticketswap.atlassian.net/browse/GIN-1731)