### PR TITLE
feat(select): make it possible to add onClick actions to select items

### DIFF
--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Select } from './'
-import { MagnifyingGlass } from '../../icons'
+import { Select, SelectItemType } from './'
+import { MagnifyingGlass, Plus } from '../../icons'
 import { Flag } from '../Flag'
+import { color } from '../../theme'
 
 const items = [
   { value: 'de', name: 'German' },
@@ -11,6 +12,18 @@ const items = [
   { value: 'hu', name: 'Hungarian' },
   { value: 'fr', name: 'French' },
   { value: 'es', name: 'Spanish' },
+]
+
+const itemsWithActions = [
+  { value: 'ideal', name: 'iDeal' },
+  { value: 'credit_card', name: 'Credit Card' },
+  {
+    value: null,
+    name: 'My prefered payment method is missing',
+    type: SelectItemType.action,
+    leftAdornment: <Plus size={20} color={color.spaceLighter} />,
+    onClick: () => alert('That is a bummer!'),
+  },
 ]
 
 export default {
@@ -25,6 +38,18 @@ export const Basic = () => (
     help="Select a language"
     onChange={selection => console.log(selection)}
     initialSelectedItem={items[1]}
+    leftAdornment={<MagnifyingGlass size={24} />}
+  />
+)
+
+export const withActions = () => (
+  <Select
+    items={itemsWithActions}
+    id="language"
+    label="Language"
+    help="Select a language"
+    onChange={selection => console.log(selection)}
+    initialSelectedItem={itemsWithActions[0]}
     leftAdornment={<MagnifyingGlass size={24} />}
   />
 )


### PR DESCRIPTION
# Description

This change makes it possible to add an option to the select items that is not used as item but more
as action after selecting it. By using the `type` and `onClick` attribute it's possible to run a
function after selecting an item (without actually selecting the item).

## How to test

- Checkout
- See `withActions` story
- Verify everything is working as expected
- Verify mobile view is also working as expected

## Screenshots
![Screenshot 2021-12-13 at 11 55 14](https://user-images.githubusercontent.com/14276144/145800094-82b478b8-b387-4a5c-80e5-74561808b156.png)



