### PR TITLE
Add plugins to create release notes on every release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,11 +1,14 @@
 {
   "branches": ["main"],
   "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
     [
       "@semantic-release/npm",
       {
         "pkgRoot": "./dist"
       }
     ],
+    "@semantic-release/github",
   ]
 }


### PR DESCRIPTION
# Description
With the new release process the release notes where not generated anymore. This PR will add the required plugins to automagically add them again.