### PR TITLE
fix(DatePicker): Ensure January (month 0) is correctly displayed

### DIFF
--- a/src/components/DatePicker/CalendarDialog.test.tsx
+++ b/src/components/DatePicker/CalendarDialog.test.tsx
@@ -138,6 +138,35 @@ describe('CalendarDialog', () => {
         })
       ).toHaveAttribute('aria-selected')
     })
+
+    describe('and the month is January (0)', () => {
+      it('renders the dialog correctly', async () => {
+        const date = new Date(2020, 0, 20)
+
+        render(
+          <CalendarDialog
+            date={date}
+            title="Pick a date"
+            timeFrame={TimeFrame.future}
+            monthLabel="Month"
+            yearLabel="Year"
+            info="Some important info"
+            isOpen={true}
+            close={jest.fn()}
+            locale="en-EN"
+            onChange={jest.fn()}
+          />
+        )
+
+        await dialogIsOpen()
+
+        expect(
+          screen.getByRole('textbox', {
+            name: /month arrowdown/i,
+          })
+        ).toHaveDisplayValue('January')
+      })
+    })
   })
 
   describe('when a date is not initially provided', () => {

--- a/src/components/DatePicker/CalendarDialog.tsx
+++ b/src/components/DatePicker/CalendarDialog.tsx
@@ -86,8 +86,8 @@ const CalendarDialog = ({
   locale,
   onChange,
 }: CalendarDialogProps) => {
-  const month = date?.getMonth() || new Date().getMonth()
-  const year = date?.getFullYear() || new Date().getFullYear()
+  const month = date ? date.getMonth() : new Date().getMonth()
+  const year = date ? date.getFullYear() : new Date().getFullYear()
 
   const [selectedMonth, setSelectedMonth] = useState(month)
   const [selectedYear, setSelectedYear] = useState(year)


### PR DESCRIPTION
# Description

This PR fixes a condition in the DatePicker where we were wrongly evaluating if the month was defined. Since the month can have a value of 0 (January) the condition was wrongly evaluated to false in those cases.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`
- On `src/components/DatePicker/index.stories.tsx` on the initial date example use a January date (e.g. `new Date('Wed Jan 19 2022 00:00:00 GMT+0100'`) and check the issue no longer happens.

## Links

#1291 
[components/DateRangeDialog/index.js](https://github.com/TicketSwap/sirius/blob/main/components/DateRangeDialog/index.js#L77)