### PR TITLE
style(DatePicker): Improve responsiveness of input

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '../Text'
 import { Calendar } from '../../icons'
-import { space, radius, color } from '../../theme'
+import { space, radius, color, device } from '../../theme'
 import CalendarDialog from './CalendarDialog'
 import { TimeFrame } from '../../utils/dates'
 
@@ -36,8 +36,22 @@ const StyledButton = styled.button`
 `
 
 const ButtonText = styled(Text)<ButtonTextProps>`
-  margin-left: ${space[16]};
   color: ${props => (props.hasDate ? color.space : color.spaceLight)};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media ${device.mobileM} {
+    margin-left: ${space[16]};
+  }
+`
+
+const StyledCalendar = styled(Calendar)`
+  display: none;
+
+  @media ${device.mobileM} {
+    display: inline-block;
+  }
 `
 
 export const DatePicker = ({
@@ -74,7 +88,7 @@ export const DatePicker = ({
         }}
       />
       <StyledButton onClick={toggle}>
-        <Calendar size={24} color={color.spaceMedium} />
+        <StyledCalendar size={24} color={color.spaceMedium} />
         <ButtonText hasDate={!!date}>
           {!!date
             ? date.toLocaleString(locale, {


### PR DESCRIPTION
# Description

This PR improves the responsiveness of the DatePicker input by not displaying the CalendarIcon in small mobile phones and trimming the date if necessary.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`
- Chrome dev tools > responsive version

## Screenshots

<img width="415" alt="Screenshot 2021-12-22 at 15 51 57" src="https://user-images.githubusercontent.com/1096800/147111221-7a0e73a2-2d96-4906-9838-6fc85dc88d9c.png">


## To be notified

@Marruk 

## Links

https://github.com/TicketSwap/sirius/pull/5516#issuecomment-998941490