### PR TITLE
Make DatePicker timezone aware

### DIFF
--- a/src/components/DatePicker/CalendarDialog.tsx
+++ b/src/components/DatePicker/CalendarDialog.tsx
@@ -22,6 +22,7 @@ import {
   getYears,
   isPastDate,
   isFutureDate,
+  withTimezone,
 } from '../../utils/dates'
 
 const Selects = styled.div`
@@ -70,6 +71,7 @@ interface CalendarDialogProps {
   info?: string
   isOpen: boolean
   locale: string
+  timeZone: string
   close: () => void
   onChange: (date: Date) => void
 }
@@ -84,16 +86,28 @@ const CalendarDialog = ({
   isOpen,
   close,
   locale,
+  timeZone,
   onChange,
 }: CalendarDialogProps) => {
-  const month = date?.getMonth() || new Date().getMonth()
-  const year = date?.getFullYear() || new Date().getFullYear()
+  const initialDate = date || new Date()
+
+  const month = withTimezone(initialDate, timeZone, locale).getMonth()
+  const year = withTimezone(initialDate, timeZone, locale).getFullYear()
 
   const [selectedMonth, setSelectedMonth] = useState(month)
   const [selectedYear, setSelectedYear] = useState(year)
 
-  const daysInMonth = new Date(selectedYear, selectedMonth + 1, 0).getDate()
-  const firstDayOfMonth = new Date(selectedYear, selectedMonth, 1).getDay()
+  const daysInMonth = withTimezone(
+    new Date(selectedYear, selectedMonth + 1, 0),
+    timeZone,
+    locale
+  ).getDate()
+
+  const firstDayOfMonth = withTimezone(
+    new Date(selectedYear, selectedMonth, 1),
+    timeZone,
+    locale
+  ).getDay()
 
   const weekdays = getWeekdays(locale)
   const months = getMonths(locale)
@@ -102,10 +116,14 @@ const CalendarDialog = ({
   const days: Array<React.ReactNode> = []
 
   for (let i = 1; i < daysInMonth + 1; i++) {
-    const day = new Date(selectedYear, selectedMonth, i)
+    const day = withTimezone(
+      new Date(selectedYear, selectedMonth, i),
+      timeZone,
+      locale
+    )
     const isDisabled =
-      (timeFrame === TimeFrame.future && isPastDate(day)) ||
-      (timeFrame === TimeFrame.past && isFutureDate(day))
+      (timeFrame === TimeFrame.future && isPastDate(day, timeZone, locale)) ||
+      (timeFrame === TimeFrame.past && isFutureDate(day, timeZone, locale))
 
     days.push(
       <Day

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -20,6 +20,7 @@ interface DatePickerProps {
   monthLabel: string
   yearLabel: string
   locale?: string
+  timeZone?: string
   onChange: (date: Date) => void
 }
 
@@ -49,6 +50,7 @@ export const DatePicker = ({
   monthLabel,
   yearLabel,
   locale = 'en-US',
+  timeZone = 'CET',
   onChange,
 }: DatePickerProps) => {
   const [isOpen, setOpen] = useState(false)
@@ -66,6 +68,7 @@ export const DatePicker = ({
         monthLabel={monthLabel}
         yearLabel={yearLabel}
         locale={locale}
+        timeZone={timeZone}
         isOpen={isOpen}
         close={close}
         onChange={(date: Date) => {
@@ -81,6 +84,7 @@ export const DatePicker = ({
                 day: 'numeric',
                 month: 'short',
                 year: 'numeric',
+                timeZone,
               })
             : placeholder}
         </ButtonText>

--- a/src/utils/dates/index.ts
+++ b/src/utils/dates/index.ts
@@ -5,12 +5,16 @@ export enum TimeFrame {
 }
 
 const dateWithoutHours = (date: Date) => date.setHours(0, 0, 0, 0)
+const withTimezone = (date: Date, timeZone: string, locale: string) =>
+  new Date(date.toLocaleString(locale, { timeZone }))
 
 const isSameDate = (dateOne: Date, dateTwo: Date) =>
   dateWithoutHours(dateOne) === dateWithoutHours(dateTwo)
-const isPastDate = (date: Date) =>
-  dateWithoutHours(date) - dateWithoutHours(new Date()) < 0
-const isFutureDate = (date: Date) =>
+const isPastDate = (date: Date, timeZone: string, locale: string) =>
+  dateWithoutHours(date) -
+    dateWithoutHours(withTimezone(new Date(), timeZone, locale)) <
+  0
+const isFutureDate = (date: Date, timeZone: string, locale: string) =>
   dateWithoutHours(date) - dateWithoutHours(new Date()) > 0
 
 const getWeekdays = (locale: string) => {
@@ -77,6 +81,7 @@ const getYears = (
 }
 
 export {
+  withTimezone,
   isSameDate,
   isPastDate,
   isFutureDate,


### PR DESCRIPTION
# Description

As a user of this component, I might want to display the days in a different time zone. For instance, when I'm picking an event date in Australia, the day of the event might be on a different day / week day than my local time. 

## Changes

- [ ] This has been done
- [x] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`

## To be notified

@Marruk @samybasset 
