### PR TITLE
fix(DatePicker): Calendar not updated when date prop changed indirectly

### DIFF
--- a/src/components/DatePicker/CalendarDialog.tsx
+++ b/src/components/DatePicker/CalendarDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useState } from 'react'
 import styled from '@emotion/styled'
 import {
@@ -100,6 +100,16 @@ const CalendarDialog = ({
   const years = getYears(timeFrame)
 
   const days: Array<React.ReactNode> = []
+
+  useEffect(() => {
+    if (!date) return
+
+    const month = date.getMonth()
+    const year = date.getFullYear()
+
+    setSelectedMonth(month)
+    setSelectedYear(year)
+  }, [date])
 
   for (let i = 1; i < daysInMonth + 1; i++) {
     const day = new Date(selectedYear, selectedMonth, i)


### PR DESCRIPTION
This PR fixes an issue where the calendar was not being displayed correctly when the given date changed indirectly (i.e. not by clicking and selecting the date, but by passing a new prop eventually changed by another component). This PR also introduces a specific test for this scenario.

This issue was reported here: https://github.com/TicketSwap/sirius/pull/5516#issuecomment-1000764232 
> I think the state is still set to 2021, hence it shows today's day as the earliest possible date to select.

JIRA GIN-1718

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`

## Screenshots

https://user-images.githubusercontent.com/1096800/148078934-9672eeb0-4d1f-463a-b7f6-9a4243b8dace.mov

## To be notified

@bobbonius 
@glenngijsberts 

## Links

https://github.com/TicketSwap/sirius/pull/5516