### PR TITLE
feat (DatePicker): Custom time frame with date range [GIN-1846]

### DIFF
--- a/src/components/DatePicker/CalendarDialog.test.tsx
+++ b/src/components/DatePicker/CalendarDialog.test.tsx
@@ -383,6 +383,45 @@ describe('CalendarDialog', () => {
     })
   })
 
+  describe('when the timeFrame is custom', () => {
+    beforeEach(() => {
+      jest.useFakeTimers('modern')
+      jest.setSystemTime(Date.parse('2020-11-18T00:00:00Z'))
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('disables dates outside of the dateRange', async () => {
+      render(
+        <CalendarDialog
+          date={null}
+          title="Pick a date"
+          timeFrame={TimeFrame.custom}
+          dateRange={{
+            start: new Date('02-10-2023'),
+            end: new Date('02-15-2023'),
+          }}
+          monthLabel="Month"
+          yearLabel="Year"
+          info="Some important info"
+          isOpen={true}
+          close={jest.fn()}
+          locale="en-EN"
+          onChange={jest.fn()}
+        />
+      )
+
+      await dialogIsOpen()
+
+      expect(screen.getByRole('button', { name: '16' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: '17' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: '9' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: '8' })).toBeDisabled()
+    })
+  })
+
   describe('when the timeFrame is all', () => {
     beforeEach(() => {
       jest.useFakeTimers('modern')

--- a/src/components/DatePicker/CalendarDialog.tsx
+++ b/src/components/DatePicker/CalendarDialog.tsx
@@ -117,7 +117,11 @@ const CalendarDialog = ({
   const days: Array<React.ReactNode> = []
 
   useEffect(() => {
-    if (!date) return
+    if (!date) {
+      setSelectedMonth(initialMonth)
+      setSelectedYear(initialYear)
+      return
+    }
 
     const month = date.getMonth()
     const year = date.getFullYear()

--- a/src/components/DatePicker/index.stories.tsx
+++ b/src/components/DatePicker/index.stories.tsx
@@ -125,6 +125,24 @@ export const WithTitle = () => {
 
 WithTitle.storyName = 'With title'
 
+export const WithResetButton = () => {
+  const [date, setDate] = useState(null)
+
+  return (
+    <DatePicker
+      date={date}
+      title="Pick a date"
+      monthLabel="Month"
+      yearLabel="Year"
+      placeholder="Pick a date"
+      onChange={date => setDate(date)}
+      onReset={() => setDate(null)}
+    />
+  )
+}
+
+WithResetButton.storyName = 'With reset button'
+
 export const WithInfo = () => {
   const [date, setDate] = useState(null)
 

--- a/src/components/DatePicker/index.stories.tsx
+++ b/src/components/DatePicker/index.stories.tsx
@@ -95,8 +95,8 @@ export const WithTimeRange = () => {
       date={date}
       timeFrame={TimeFrame.custom}
       dateRange={{
-        start: new Date('02-12-2023'),
-        end: new Date('04-20-2023'),
+        start: new Date(2023, 2, 12),
+        end: new Date(2023, 4, 20),
       }}
       monthLabel="Month"
       yearLabel="Year"

--- a/src/components/DatePicker/index.stories.tsx
+++ b/src/components/DatePicker/index.stories.tsx
@@ -87,6 +87,27 @@ export const All = () => {
 
 All.storyName = 'All dates'
 
+export const WithTimeRange = () => {
+  const [date, setDate] = useState(null)
+
+  return (
+    <DatePicker
+      date={date}
+      timeFrame={TimeFrame.custom}
+      dateRange={{
+        start: new Date('02-12-2023'),
+        end: new Date('04-20-2023'),
+      }}
+      monthLabel="Month"
+      yearLabel="Year"
+      placeholder="Pick a date"
+      onChange={date => setDate(date)}
+    />
+  )
+}
+
+WithTimeRange.storyName = 'With a time range'
+
 export const WithTitle = () => {
   const [date, setDate] = useState(null)
 

--- a/src/components/DatePicker/index.test.tsx
+++ b/src/components/DatePicker/index.test.tsx
@@ -44,6 +44,38 @@ describe('DatePicker', () => {
 
       expect(screen.getByText(/Feb 1, 2020/i)).toBeInTheDocument()
     })
+
+    it('allows you to clear the date when onReset is passed', async () => {
+      const TestScenario = () => {
+        const [startDate, setStartDate] = useState(new Date(2020, 1, 1))
+
+        return (
+          <>
+            <DatePicker
+              date={startDate}
+              placeholder="From"
+              title="Pick a date"
+              timeFrame={TimeFrame.future}
+              monthLabel="Month"
+              yearLabel="Year"
+              info="Some important info"
+              locale="en-EN"
+              resetLabel="Clear"
+              onChange={date => setStartDate(date)}
+              onReset={() => setStartDate(null)}
+            />
+          </>
+        )
+      }
+      render(<TestScenario />)
+
+      expect(screen.getByText(/Feb 1, 2020/i)).toBeInTheDocument()
+
+      const resetButton = screen.getByLabelText('Clear')
+      userEvent.click(resetButton)
+
+      expect(screen.getByText(/from/i)).toBeInTheDocument()
+    })
   })
 
   describe('when open', () => {

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -14,6 +14,7 @@ interface ButtonTextProps {
 interface DatePickerProps {
   date?: Date | null
   placeholder: string
+  resetLabel?: string
   title?: string
   timeFrame?: TimeFrame
   dateRange?: { start: Date; end: Date }
@@ -79,6 +80,7 @@ export const DatePicker = ({
   monthLabel,
   yearLabel,
   locale = 'en-US',
+  resetLabel,
   onChange,
   onReset,
 }: DatePickerProps) => {
@@ -125,7 +127,7 @@ export const DatePicker = ({
               e.stopPropagation()
             }}
             type="button"
-            data-testid="reset-button"
+            aria-label={resetLabel}
           >
             <CloseRounded size={16} />
           </ResetButton>

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { useState } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '../Text'
-import { Calendar } from '../../icons'
-import { space, radius, color, device } from '../../theme'
+import { Calendar, CloseRounded } from '../../icons'
+import { space, radius, color, device, transition } from '../../theme'
 import CalendarDialog from './CalendarDialog'
 import { TimeFrame } from '../../utils/dates'
 
@@ -22,6 +22,7 @@ interface DatePickerProps {
   yearLabel: string
   locale?: string
   onChange: (date: Date) => void
+  onReset?: () => void
 }
 
 const StyledButton = styled.button`
@@ -32,6 +33,7 @@ const StyledButton = styled.button`
   font-family: inherit;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   margin-bottom: ${space[8]};
   width: 100%;
 `
@@ -55,6 +57,18 @@ const StyledCalendar = styled(Calendar)`
   }
 `
 
+const ResetButton = styled.button`
+  line-height: 0;
+  opacity: 0.35;
+  transition: opacity ${transition};
+
+  &:hover,
+  &:focus {
+    opacity: 0.5;
+    outline: 0;
+  }
+`
+
 export const DatePicker = ({
   date = null,
   placeholder,
@@ -66,6 +80,7 @@ export const DatePicker = ({
   yearLabel,
   locale = 'en-US',
   onChange,
+  onReset,
 }: DatePickerProps) => {
   const [isOpen, setOpen] = useState(false)
 
@@ -91,16 +106,30 @@ export const DatePicker = ({
         }}
       />
       <StyledButton onClick={toggle}>
-        <StyledCalendar size={24} color={color.spaceMedium} />
-        <ButtonText hasDate={!!date}>
-          {!!date
-            ? date.toLocaleString(locale, {
-                day: 'numeric',
-                month: 'short',
-                year: 'numeric',
-              })
-            : placeholder}
-        </ButtonText>
+        <div>
+          <StyledCalendar size={24} color={color.spaceMedium} />
+          <ButtonText hasDate={!!date}>
+            {!!date
+              ? date.toLocaleString(locale, {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric',
+                })
+              : placeholder}
+          </ButtonText>
+        </div>
+        {onReset && date && (
+          <ResetButton
+            onClick={e => {
+              onReset()
+              e.stopPropagation()
+            }}
+            type="button"
+            data-testid="reset-button"
+          >
+            <CloseRounded size={16} />
+          </ResetButton>
+        )}
       </StyledButton>
     </>
   )

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -16,6 +16,7 @@ interface DatePickerProps {
   placeholder: string
   title?: string
   timeFrame?: TimeFrame
+  dateRange?: { start: Date; end: Date }
   info?: string
   monthLabel: string
   yearLabel: string
@@ -59,6 +60,7 @@ export const DatePicker = ({
   placeholder,
   title,
   timeFrame = TimeFrame.future,
+  dateRange,
   info,
   monthLabel,
   yearLabel,
@@ -76,6 +78,7 @@ export const DatePicker = ({
         date={date}
         title={title}
         timeFrame={timeFrame}
+        dateRange={dateRange}
         info={info}
         monthLabel={monthLabel}
         yearLabel={yearLabel}

--- a/src/utils/dates/index.test.ts
+++ b/src/utils/dates/index.test.ts
@@ -147,6 +147,30 @@ describe('dates', () => {
       ])
     })
 
+    it('returns only the months within a timeRange', () => {
+      const monthsOfTimeRange = getMonths('en-EN', {
+        start: new Date('02-12-2023'),
+        end: new Date('04-20-2023'),
+      })
+      expect(monthsOfTimeRange).toHaveLength(3)
+      expect(monthsOfTimeRange).toEqual(
+        expect.arrayContaining([
+          {
+            name: 'February',
+            value: '1',
+          },
+          {
+            name: 'March',
+            value: '2',
+          },
+          {
+            name: 'April',
+            value: '3',
+          },
+        ])
+      )
+    })
+
     describe('when provided with different "BCP 47" locale tags', () => {
       it('translates them correctly', () => {
         const nl_months = getMonths('nl-NL')
@@ -206,7 +230,11 @@ describe('dates', () => {
   describe('getYears', () => {
     describe('when the timeFrame is "all"', () => {
       it('includes past and future years', () => {
-        const years = getYears(TimeFrame.all, 1)
+        const years = getYears({
+          timeFrame: TimeFrame.all,
+          range: 1,
+          yearOfReference: new Date().getFullYear(),
+        })
 
         expect(years).toEqual([
           {
@@ -228,7 +256,11 @@ describe('dates', () => {
 
   describe('when the timeFrame is "past"', () => {
     it('includes past years', () => {
-      const years = getYears(TimeFrame.past, 1)
+      const years = getYears({
+        timeFrame: TimeFrame.past,
+        range: 1,
+        yearOfReference: new Date().getFullYear(),
+      })
 
       expect(years).toEqual([
         {
@@ -245,7 +277,11 @@ describe('dates', () => {
 
   describe('when the timeFrame is "future"', () => {
     it('includes future years', () => {
-      const years = getYears(TimeFrame.future, 1)
+      const years = getYears({
+        timeFrame: TimeFrame.future,
+        range: 1,
+        yearOfReference: new Date().getFullYear(),
+      })
 
       expect(years).toEqual([
         {
@@ -260,19 +296,31 @@ describe('dates', () => {
     })
   })
 
-  describe('when the range is not specified', () => {
-    it('displays a range of 20 years', () => {
-      const years = getYears(TimeFrame.all)
+  describe('when the timeFrame is all and the range default to 10', () => {
+    it('displays a range of 20 years (10y before and after current year)', () => {
+      const years = getYears({
+        timeFrame: TimeFrame.all,
+        range: 10,
+        yearOfReference: new Date().getFullYear(),
+      })
 
       expect(years).toHaveLength(21)
     })
   })
 
-  describe('when the timeFrame is not specified', () => {
-    it('displays the future years', () => {
-      const years = getYears()
+  describe('when the timeFrame is custom', () => {
+    it('displays the years within date range', () => {
+      const dateRange = {
+        start: new Date('02-12-2023'),
+        end: new Date('04-20-2024'),
+      }
+      const years = getYears({
+        timeFrame: TimeFrame.custom,
+        range: dateRange.end.getFullYear() - dateRange.start.getFullYear(),
+        yearOfReference: dateRange.start.getFullYear(),
+      })
 
-      expect(years).toHaveLength(11)
+      expect(years).toHaveLength(2)
     })
   })
 })

--- a/src/utils/dates/index.ts
+++ b/src/utils/dates/index.ts
@@ -2,16 +2,17 @@ export enum TimeFrame {
   all = 'all',
   past = 'past',
   future = 'future',
+  custom = 'custom',
 }
 
 const dateWithoutHours = (date: Date) => date.setHours(0, 0, 0, 0)
 
 const isSameDate = (dateOne: Date, dateTwo: Date) =>
   dateWithoutHours(dateOne) === dateWithoutHours(dateTwo)
-const isPastDate = (date: Date) =>
-  dateWithoutHours(date) - dateWithoutHours(new Date()) < 0
-const isFutureDate = (date: Date) =>
-  dateWithoutHours(date) - dateWithoutHours(new Date()) > 0
+const isPastDate = (date: Date, dateOfReference: Date = new Date()) =>
+  dateWithoutHours(date) - dateWithoutHours(dateOfReference) < 0
+const isFutureDate = (date: Date, dateOfReference: Date = new Date()) =>
+  dateWithoutHours(date) - dateWithoutHours(dateOfReference) > 0
 
 const getWeekdays = (locale: string) => {
   const weekdays = []
@@ -27,7 +28,7 @@ const getWeekdays = (locale: string) => {
   return weekdays
 }
 
-const getMonths = (locale: string) => {
+const getMonths = (locale: string, dateRange?: { start: Date; end: Date }) => {
   const months = []
 
   for (let i = 0; i < 12; i++) {
@@ -39,6 +40,14 @@ const getMonths = (locale: string) => {
       name: String(month),
       value: String(i),
     })
+  }
+
+  if (dateRange) {
+    return months.filter(
+      month =>
+        Number(month.value) >= dateRange.start.getMonth() &&
+        Number(month.value) <= dateRange.end.getMonth()
+    )
   }
 
   return months
@@ -59,21 +68,26 @@ const generateYears = (startYear: number, endYear: number) => {
   return years
 }
 
-const getYears = (
-  timeFrame: TimeFrame = TimeFrame.future,
-  range: number = 10
-) => {
-  const currentYear = new Date().getFullYear()
+interface YearParams {
+  timeFrame: TimeFrame
+  range: number
+  yearOfReference: number
+}
 
+const getYears = ({ timeFrame, range, yearOfReference }: YearParams) => {
   if (timeFrame === TimeFrame.all) {
-    return generateYears(currentYear - range, currentYear + range)
+    return generateYears(yearOfReference - range, yearOfReference + range)
   }
 
   if (timeFrame === TimeFrame.past) {
-    return generateYears(currentYear - range, currentYear)
+    return generateYears(yearOfReference - range, yearOfReference)
   }
 
-  return generateYears(currentYear, currentYear + range)
+  if (timeFrame === TimeFrame.custom) {
+    return generateYears(yearOfReference - range, yearOfReference)
+  }
+
+  return generateYears(yearOfReference, yearOfReference + range)
 }
 
 export {


### PR DESCRIPTION
# Description
After introducing the new day picker, we want to facilitate the UX for ongoing events by allowing the user to pick dates only from the dateRange of the event. The rest of the dates will be disabled + implementation of clear button (only showing when there is a value in the date field). 

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn storybook` 
- Go to datePicker story: ' With time range '
- Check that it disabled the dates outside of the dateRange pass to the component 
- Check that both the year and month selects are limited to the months and year within the validity 
- Check that the datePicker opens on the first month of the start date of the dateRange
- Go to the story ' With reset button '
- Make sure it clear both dates on click x and that the x shows only if the date value is not null

## Screenshots
<img width="550" alt="Screenshot 2022-01-05 at 17 49 27" src="https://user-images.githubusercontent.com/34305012/148256288-03502529-56af-47fc-a772-7d89ca892329.png">
<img width="410" alt="Screenshot 2022-01-10 at 09 44 18" src="https://user-images.githubusercontent.com/34305012/148738454-c4115037-efd6-4527-ad59-b84579f11099.png">


## To be notified

Tag anyone who should be informed of the proposed changes.

## Links
https://ticketswap.atlassian.net/browse/GIN-1846
Related content such as articles, Slack messages or Jira stories.
