### PR TITLE
feat(DatePicker): fix nested button console error

### DIFF
--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -58,7 +58,7 @@ const StyledCalendar = styled(Calendar)`
   }
 `
 
-const ResetButton = styled.button`
+const ResetButton = styled.span`
   line-height: 0;
   opacity: 0.35;
   transition: opacity ${transition};
@@ -126,7 +126,6 @@ export const DatePicker = ({
               onReset()
               e.stopPropagation()
             }}
-            type="button"
             aria-label={resetLabel}
           >
             <CloseRounded size={16} />


### PR DESCRIPTION
# Description

See title ,

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Go to sirius, to datePicker with a range (for ex on event type page)
- Make sure there is no console error related to nested button in sirius
