### PR TITLE
Fix the auto import of solar components in IDE's

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.tsx"],
+  "include": ["src/**/*.tsx", "src/**/*.ts"],
   "exclude": ["src/**/*.stories.tsx", "src/**/*.test.tsx"],
   "compilerOptions": {
     "noImplicitAny": true,


### PR DESCRIPTION
# Description
The declaration files of .ts files were not created because they weren't included in the tsconfig.
This caused your IDE to import the components/utils not from the index (@ticketswap/solar) but from the specific file they are in (@ticketswap/solar/button). This is fixed now 🎉 

## Changes
Added `.ts` files to the tsconfig.
