### PR TITLE
Avatar src can be nullable

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -66,7 +66,7 @@ const Placeholder = () => (
 
 export interface AvatarProps {
   size?: number
-  src?: string
+  src?: string | null
   alt?: string
 }
 


### PR DESCRIPTION
# Description
Avatar src prop can be null, so I added it to the type declaration

Before this change you needed to do
```js
const imageSrc = null

<Avatar src={imageSrc || undefined} />
```
