### PR TITLE
Fix ContentDialogHeader title color in dark mode

### DIFF
--- a/src/components/ContentDialog/index.tsx
+++ b/src/components/ContentDialog/index.tsx
@@ -282,6 +282,18 @@ const StyledClose = styled(Close)`
 
 const Subtitle = styled(Text)`
   color: ${color.stardustLightAlpha};
+
+  [data-theme='dark'] & {
+    color: ${color.spaceMedium};
+  }
+`
+
+const Title = styled(H2)`
+  color: ${color.nova};
+
+  [data-theme='dark'] & {
+    color: ${color.space};
+  }
 `
 
 interface ContentDialogHeaderProps {
@@ -301,7 +313,7 @@ const ContentDialogHeader = React.forwardRef<
     <div ref={ref}>
       <StyledCover imageUrl={imageUrl} blurred={blurred}>
         {logoUrl && <LogoImage logoUrl={logoUrl} />}
-        <H2>{title}</H2>
+        <Title>{title}</Title>
         {subtitle && <Subtitle>{subtitle}</Subtitle>}
         <CloseButton onClick={onDismiss}>
           <StyledClose size={16} />


### PR DESCRIPTION
# Description

We have a style bug in our production app, where the titles of the ContentDialogHeader (e.g. discovery feed) are using colors from light mode. This PR will make sure we use proper colors for dark mode.

## How to test

It's a bit hard to test, because dialogs in Storybook are not properly using dark mode due to the fact that the portal of dialogs are outside the storybook portal. What you can do is:

* Use element inspector
* Inspect the dialog
* Add `data-theme="dark"` to a parent div
* Verify the dialog is now in dark mode, with proper colors

## Screenshots

New
![Screenshot 2022-02-03 at 14 16 59](https://user-images.githubusercontent.com/14276144/152350112-07302aff-9a5b-4652-b2f7-f0a4f518463e.png)

Old
![Screenshot 2022-02-03 at 14 17 26](https://user-images.githubusercontent.com/14276144/152350173-695774ea-70eb-45ac-8e05-1b494c5c3dcc.png)

