### PR TITLE
feat(datePicker): allowing to hide frontAdornment

### DIFF
--- a/src/components/DatePicker/index.stories.tsx
+++ b/src/components/DatePicker/index.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { DatePicker, TimeFrame } from '.'
+import { Calendar } from '../../icons'
 
 export default {
   title: 'Components/Inputs/DatePicker',
@@ -14,12 +15,29 @@ export const Simple = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
 }
 
 Simple.storyName = 'Without initial date'
+
+export const NoLeftAdornment = () => {
+  const [date, setDate] = useState(null)
+
+  return (
+    <DatePicker
+      date={date}
+      monthLabel="Month"
+      yearLabel="Year"
+      placeholder="Pick a date"
+      onChange={date => setDate(date)}
+    />
+  )
+}
+
+NoLeftAdornment.storyName = 'With no left adornment'
 
 export const InitialDate = () => {
   const [date, setDate] = useState(new Date())
@@ -30,6 +48,7 @@ export const InitialDate = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
@@ -46,6 +65,7 @@ export const Future = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
@@ -63,6 +83,7 @@ export const Past = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
@@ -80,6 +101,7 @@ export const All = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
@@ -101,6 +123,7 @@ export const WithTimeRange = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
@@ -118,6 +141,7 @@ export const WithTitle = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )
@@ -135,6 +159,7 @@ export const WithResetButton = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
       onReset={() => setDate(null)}
     />
@@ -153,6 +178,7 @@ export const WithInfo = () => {
       monthLabel="Month"
       yearLabel="Year"
       placeholder="Pick a date"
+      leftAdornment={<Calendar size={24} />}
       onChange={date => setDate(date)}
     />
   )

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
-import { useState } from 'react'
+import { useState, ReactNode } from 'react'
 import styled from '@emotion/styled'
 import { Text } from '../Text'
-import { Calendar, CloseRounded } from '../../icons'
+import { CloseRounded } from '../../icons'
 import { space, radius, color, device, transition } from '../../theme'
 import CalendarDialog from './CalendarDialog'
 import { TimeFrame } from '../../utils/dates'
 
 interface ButtonTextProps {
   hasDate: boolean
+  leftAdornment?: ReactNode
 }
 
 interface DatePickerProps {
@@ -22,6 +23,7 @@ interface DatePickerProps {
   monthLabel: string
   yearLabel: string
   locale?: string
+  leftAdornment?: ReactNode
   onChange: (date: Date) => void
   onReset?: () => void
 }
@@ -46,11 +48,11 @@ const ButtonText = styled(Text)<ButtonTextProps>`
   text-overflow: ellipsis;
 
   @media ${device.mobileM} {
-    margin-left: ${space[16]};
+    margin-left: ${props => (props.leftAdornment ? space[16] : 0)};
   }
 `
 
-const StyledCalendar = styled(Calendar)`
+const LeftAdornment = styled.span`
   display: none;
 
   @media ${device.mobileM} {
@@ -83,6 +85,7 @@ export const DatePicker = ({
   resetLabel,
   onChange,
   onReset,
+  leftAdornment,
 }: DatePickerProps) => {
   const [isOpen, setOpen] = useState(false)
 
@@ -109,8 +112,8 @@ export const DatePicker = ({
       />
       <StyledButton onClick={toggle}>
         <div>
-          <StyledCalendar size={24} color={color.spaceMedium} />
-          <ButtonText hasDate={!!date}>
+          <LeftAdornment>{leftAdornment}</LeftAdornment>
+          <ButtonText hasDate={!!date} leftAdornment={leftAdornment}>
             {!!date
               ? date.toLocaleString(locale, {
                   day: 'numeric',


### PR DESCRIPTION
# Description

Along with the revamp of the TicketAlert modals, it was required to remove the calendar adornment in the front. This PR is hiding it if the props is false. `withFrontAdornment` default to `true`

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn run storybook`
- search for datePicker 
- check that there is no calendar icon in the front in the story "With no front adornment"
- verify there is a calendar icon in the other stories 

## Screenshots
<img width="521" alt="Screenshot 2022-02-08 at 16 17 43" src="https://user-images.githubusercontent.com/34305012/153017097-3bf76377-24e6-41a4-8b2c-930d30f9a458.png">
<img width="515" alt="Screenshot 2022-02-08 at 16 17 52" src="https://user-images.githubusercontent.com/34305012/153017109-4e89ee6d-3efc-4d80-92b4-c4524ecb138f.png">

## To be notified
@TicketSwap/frontend 

## Links
https://ticketswap.atlassian.net/browse/GIN-1787
