### PR TITLE
Fix transition state type

### DIFF
--- a/src/components/ContentDialog/index.tsx
+++ b/src/components/ContentDialog/index.tsx
@@ -39,12 +39,7 @@ const duration = 200
 
 interface StyledTransitionProps {
   onScroll?: Function
-  state:
-    | TransitionState.ENTERED
-    | TransitionState.ENTERING
-    | TransitionState.EXITED
-    | TransitionState.EXITING
-    | boolean // @TODO: Why is `state` boolean | TransitionState?
+  state: TransitionState
 }
 
 const StyledDialogOverlay = styled<React.FC<DialogOverlayProps>>(

--- a/src/components/ContentTransition/index.tsx
+++ b/src/components/ContentTransition/index.tsx
@@ -11,12 +11,7 @@ const Container = styled.div`
 `
 
 interface SlideContainerProps {
-  state:
-    | TransitionState.ENTERED
-    | TransitionState.ENTERING
-    | TransitionState.EXITED
-    | TransitionState.EXITING
-    | boolean
+  state: TransitionState
   from: string
   to: string
   initial: boolean

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -58,7 +58,7 @@ export interface DialogProps extends UseDialogProps {
 }
 
 interface DialogOverlayStyles {
-  state: boolean | TransitionState
+  state: TransitionState
 }
 
 const DialogOverlay = styled.div<DialogOverlayStyles>`
@@ -93,7 +93,7 @@ const DialogOverlay = styled.div<DialogOverlayStyles>`
 `
 
 interface ContentStyles {
-  state?: boolean | TransitionState
+  state?: TransitionState
 }
 
 const Content = styled.div<ContentStyles>`

--- a/src/components/MenuButton/index.tsx
+++ b/src/components/MenuButton/index.tsx
@@ -34,7 +34,7 @@ export const Menu = ({ children, ...props }: MenuProps) => {
 }
 
 export interface MenuListProps extends ReachMenuListProps {
-  state: boolean | TransitionState
+  state: TransitionState
 }
 
 const StyledMenuList = styled<React.FC<MenuListProps>>(ReachMenuList)`

--- a/src/components/OnboardingDialog/index.tsx
+++ b/src/components/OnboardingDialog/index.tsx
@@ -40,7 +40,7 @@ const DialogWrapper = styled.div<DialogWrapperProps>`
 
 export interface OnboardingDialogProps {
   show: boolean
-  state: TransitionState | boolean
+  state: TransitionState
   active: boolean
 }
 
@@ -70,7 +70,7 @@ const Container = styled.div`
 `
 
 interface BackdropProps {
-  state: TransitionState | boolean
+  state: TransitionState
 }
 
 const Backdrop = styled.div<BackdropProps>`

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -23,7 +23,7 @@ const ItemListContainer = styled.ul`
 `
 
 interface ItemContainerStyles {
-  state: boolean | TransitionState
+  state: TransitionState
 }
 
 const ItemContainer = styled.li<ItemContainerStyles>`

--- a/src/hooks/useTransition.ts
+++ b/src/hooks/useTransition.ts
@@ -31,7 +31,7 @@ export function useTransition({
   onEntering,
   onEntered,
   onExiting,
-}: useTransitionParameters) {
+}: useTransitionParameters): [TransitionState, boolean, boolean] {
   if (typeof on !== 'boolean') throwError('in')
   if (typeof timeout !== 'number') throwError('timeout')
   const [state, setState] = React.useState(defaultTransitionState)


### PR DESCRIPTION
# Description
The return type of the useTransition hook was `TransitionState | boolean`. This should have been `[TransitionState, boolean, boolean]` because it returns an array with three values.