### PR TITLE
Replace Semantic Pull Request app for action

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,2 +1,0 @@
-# Always validate all commits, and ignore the PR title
-commitsOnly: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
       - run: yarn install
       - run: yarn validate
 
+  semantic_commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v4
+
   semantic_release:
     runs-on: ubuntu-latest
     needs: [tests]


### PR DESCRIPTION
## Desciption

This PR will replace the Semantic Pull Request app with a github action called `semantic_commits`

It basically does the same but we have more control over it and it doesn't break every week.

![afbeelding](https://user-images.githubusercontent.com/22071649/153141962-ecc28ad6-1c23-4632-a21e-447f124c1299.png)
