### PR TITLE
Toast: add left adornment on toast component

### DIFF
--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -4,6 +4,8 @@ import { Button, ButtonSize, ButtonVariant } from '../Button'
 import { Select } from '../Select'
 import styled from '@emotion/styled'
 import { Text } from '../Text'
+import { CheckmarkRounded } from '../../icons'
+import { color, space } from '../../theme'
 
 const ToastContent = styled.div`
   display: flex;
@@ -23,7 +25,28 @@ function Basic() {
       onClick={() =>
         notify(() => (
           <Toast>
-            <ToastContent>Notification</ToastContent>
+            <Text>Notification</Text>
+          </Toast>
+        ))
+      }
+    >
+      Show toast
+    </Button>
+  )
+}
+
+function WithAdornment() {
+  const { notify } = useToast()
+
+  return (
+    <Button
+      onClick={() =>
+        notify(() => (
+          <Toast
+            persist
+            leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
+          >
+            <Text>Your preferences have been successfully updated</Text>
           </Toast>
         ))
       }
@@ -95,13 +118,77 @@ function Persistent() {
   )
 }
 
+const ButtonWrapper = styled.div`
+  display: grid;
+  grid-gap: ${space[8]};
+`
+
+function PersistentWithAdornment() {
+  const { notify } = useToast()
+
+  return (
+    <ButtonWrapper>
+      <Button
+        onClick={() =>
+          notify(remove => (
+            <Toast
+              persist
+              leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
+            >
+              <ToastContent>
+                <Text>Your preferences have been successfully updated</Text>
+                <Button
+                  onClick={remove}
+                  size={ButtonSize.medium}
+                  variant={ButtonVariant.secondary}
+                >
+                  Discard
+                </Button>
+              </ToastContent>
+            </Toast>
+          ))
+        }
+      >
+        Show toast with multiple lines
+      </Button>
+      <Button
+        onClick={() =>
+          notify(remove => (
+            <Toast
+              persist
+              leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
+            >
+              <ToastContent>
+                <Text>Saved!</Text>
+                <Button
+                  onClick={remove}
+                  size={ButtonSize.medium}
+                  variant={ButtonVariant.secondary}
+                >
+                  Discard
+                </Button>
+              </ToastContent>
+            </Toast>
+          ))
+        }
+      >
+        Show toast with one line
+      </Button>
+    </ButtonWrapper>
+  )
+}
+
 export const BasicToast = () => <Basic />
+export const WithAdornmentToast = () => <WithAdornment />
 export const WithInputToast = () => <WithInput />
 export const PersistentToast = () => <Persistent />
+export const PersistentWithAdornmentToast = () => <PersistentWithAdornment />
 
 BasicToast.storyName = 'Basic'
+WithAdornmentToast.storyName = 'With Adornment'
 WithInputToast.storyName = 'With Input'
 PersistentToast.storyName = 'Persistent'
+PersistentWithAdornmentToast.storyName = 'Persistent with Adornment'
 
 export default {
   title: 'Components/Feedback/Toast',

--- a/src/components/Toast/index.test.tsx
+++ b/src/components/Toast/index.test.tsx
@@ -21,7 +21,7 @@ describe('Toast', () => {
     expect(getAllByText(/notification/i)).toHaveLength(2)
   })
 
-  it('hides toast ', () => {
+  it('hides toast', () => {
     const { getByText, queryByText } = render(
       <ToastProvider>
         <ToastConsumer>


### PR DESCRIPTION
# Description
Adds a left adornment prop on the toast component for adding icons on your toast message.

When toast content has one line, center the left adornment.
<img width="759" alt="afbeelding" src="https://user-images.githubusercontent.com/22071649/153229369-ee804e1f-44ec-439b-9088-41d7590f9e00.png">

When toast content is higher show left adornment in the top left corner.
<img width="769" alt="afbeelding" src="https://user-images.githubusercontent.com/22071649/153229020-303dcdf1-841d-42cd-a833-201bc6218208.png">

Fixes https://github.com/TicketSwap/solar/issues/1186