### PR TITLE
ci(commitlint.config.js): override body-max-line-length rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,5 +6,6 @@ module.exports = {
       'always',
       ['sentence-case', 'start-case', 'lower-case'],
     ],
+    'body-max-line-length': [2, 'always', Infinity],
   },
 }


### PR DESCRIPTION
# Description

Override body-max-line-length rule so the body of a commit message can be longer than 100 chars and
will not cause any errors when dependabot creates a PR