### PR TITLE
Only send DOM props to div in Toast component

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,11 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'subject-case': [
-      2,
-      'always',
-      ['sentence-case', 'start-case', 'lower-case'],
-    ],
+    'subject-case': [2, 'never'],
     'body-max-line-length': [2, 'always', Infinity],
   },
 }

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -28,9 +28,12 @@ export interface ToastProps {
   children: ReactNode
 }
 
-export const Toast = ({ ...props }: ToastProps) => (
-  <div {...props}>{props.children}</div>
-)
+export const Toast: React.FC<ToastProps> = ({
+  children,
+  leftAdornment,
+  persist,
+  ...props
+}) => <div {...props}>{children}</div>
 
 const LeftAdornmentContainer = styled.span`
   line-height: 0;


### PR DESCRIPTION
# Description
Destructure custom props from props before adding all props to the div element.
The div element doesn't support `persist` and `leftAdornment`
