### PR TITLE
Use own useIsomorphicLayoutEffect hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@reach/menu-button": "^0.16.2",
     "@reach/tabs": "^0.16.4",
     "@reach/tooltip": "^0.16.2",
-    "@reach/utils": "^0.16.0",
     "compute-scroll-into-view": "^1.0.16",
     "downshift": "^6.1.7"
   },

--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -1,17 +1,6 @@
 import React from 'react'
 import { createPortal } from 'react-dom'
-
-function canUseDOM() {
-  return Boolean(
-    typeof window !== 'undefined' &&
-      window.document &&
-      window.document.createElement
-  )
-}
-
-export const useIsomorphicLayoutEffect = canUseDOM()
-  ? React.useLayoutEffect
-  : React.useEffect
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect'
 
 export const Portal: React.FC = ({ children }) => {
   let mountNode = React.useRef<HTMLDivElement | null>(null)

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,4 +1,9 @@
 import { useLayoutEffect, useEffect } from 'react'
 
-export const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+const canUseDOM = Boolean(
+  typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+)
+
+export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect

--- a/src/hooks/useLockBodyScroll.ts
+++ b/src/hooks/useLockBodyScroll.ts
@@ -1,4 +1,4 @@
-import { useIsomorphicLayoutEffect as useLayoutEffect_SAFE_FOR_SSR } from '@reach/utils'
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect'
 
 const isIosDevice =
   typeof window !== 'undefined' &&
@@ -76,7 +76,7 @@ const restoreBodyScroll = () => {
 }
 
 export function useLockBodyScroll() {
-  useLayoutEffect_SAFE_FOR_SSR(() => {
+  useIsomorphicLayoutEffect(() => {
     lockBodyScroll({ reserveScrollBarGap: true })
     return () => restoreBodyScroll()
   }, [])

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,7 +73,7 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.17.3", "@babel/generator@^7.7.2":
+"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.17.0", "@babel/generator@^7.17.3", "@babel/generator@^7.7.2":
   version "7.17.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.3.tgz#a2c30b0c4f89858cb87050c3ffdfd36bdf443200"
   integrity sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==
@@ -424,7 +424,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
 
-"@babel/parser@^7.14.7", "@babel/parser@^7.17.3":
+"@babel/parser@^7.14.7", "@babel/parser@^7.17.0", "@babel/parser@^7.17.3":
   version "7.17.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.3.tgz#b07702b982990bf6fdc1da5049a23fece4c5c3d0"
   integrity sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==
@@ -2375,7 +2375,7 @@
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
 
-"@reach/utils@0.16.0", "@reach/utils@^0.16.0":
+"@reach/utils@0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
   integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==


### PR DESCRIPTION
# Description

With the newly introduced `useIsomorphicLayoutEffect` hook, we can use it instead. The PR also removes @reach/utils as it was only used for this.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn storybook`
- Check Dialog component and ContentTransition

## Links

#1370 (hook recently introduced here)