### PR TITLE
Fix overflow of elements in DialogFooter

### DIFF
--- a/src/components/Dialog/index.stories.tsx
+++ b/src/components/Dialog/index.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import {
   Dialog,
   DialogAdornment,
@@ -23,40 +23,14 @@ const items = [
   { value: 'es', name: 'Spanish' },
 ]
 
-function ControlledDialog() {
-  const [show, setShow] = React.useState(false)
-  return (
-    <>
-      <Button
-        onClick={() => setShow(!show)}
-        style={{ position: 'absolute', zIndex: 2147483647 }}
-      >
-        Toggle
-      </Button>
-      <Dialog on={show} onToggle={console.log}>
-        {({ getWindowProps }) => (
-          <DialogWindow
-            {...getWindowProps({
-              onClick: () => show && setShow(false),
-              onEscKeyDown: () => show && setShow(false),
-            })}
-          >
-            <DialogHeader>Hi</DialogHeader>
-            <DialogBody>I am a controlled dialog</DialogBody>
-          </DialogWindow>
-        )}
-      </Dialog>
-    </>
-  )
-}
-
-interface MyDialogProps {
+const BasicDialog = ({
+  children,
+  ...props
+}: {
   children: ReactNode
   persist?: boolean
   defaultOn?: boolean
-}
-
-const MyDialog = ({ children, ...props }: MyDialogProps) => (
+}) => (
   <Dialog {...props}>
     {({ hide, getToggleProps, getWindowProps }) => (
       <>
@@ -92,7 +66,34 @@ const MyDialog = ({ children, ...props }: MyDialogProps) => (
   </Dialog>
 )
 
-function HooksDialog() {
+const ControlledDialog = () => {
+  const [show, setShow] = useState(false)
+  return (
+    <>
+      <Button
+        onClick={() => setShow(!show)}
+        style={{ position: 'absolute', zIndex: 2147483647 }}
+      >
+        Toggle
+      </Button>
+      <Dialog on={show} onToggle={console.log}>
+        {({ getWindowProps }) => (
+          <DialogWindow
+            {...getWindowProps({
+              onClick: () => show && setShow(false),
+              onEscKeyDown: () => show && setShow(false),
+            })}
+          >
+            <DialogHeader>Hi</DialogHeader>
+            <DialogBody>I am a controlled dialog</DialogBody>
+          </DialogWindow>
+        )}
+      </Dialog>
+    </>
+  )
+}
+
+const HooksDialog = () => {
   const { hide, getToggleProps, getWindowProps } = useDialog({
     onToggle: (on: any) => console.log(on),
     onEntered: () => console.log('entered'),
@@ -116,21 +117,21 @@ export default {
   title: 'Components/Surfaces/Dialog',
 }
 
-export const Basic = () => <MyDialog>Body</MyDialog>
-export const DefaultOn = () => <MyDialog defaultOn>Body</MyDialog>
+export const Basic = () => <BasicDialog>Body</BasicDialog>
+export const DefaultOn = () => <BasicDialog defaultOn>Body</BasicDialog>
 
 DefaultOn.storyName = 'Default on'
 
 export const DefaultOnAndPersist = () => (
-  <MyDialog defaultOn persist>
+  <BasicDialog defaultOn persist>
     Body
-  </MyDialog>
+  </BasicDialog>
 )
 
 DefaultOnAndPersist.storyName = 'Default on and persist'
 
 export const WithLongBody = () => (
-  <MyDialog>
+  <BasicDialog>
     <div style={{ display: 'grid', gridGap: 16 }}>
       <Input id="email" type="email" label="Email address" />
       <Input id="fname" label="First name" />
@@ -144,7 +145,7 @@ export const WithLongBody = () => (
         initialSelectedItem={items[1]}
       />
     </div>
-  </MyDialog>
+  </BasicDialog>
 )
 
 WithLongBody.storyName = 'With long body'

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -244,7 +244,6 @@ export const DialogBody: React.FC = ({ children, ...props }) => {
 
 export const DialogFooter = styled.footer`
   position: relative;
-  z-index: 1;
   margin-top: -${space[16]};
   padding: ${space[16]};
   padding-bottom: calc(${space[16]} + env(safe-area-inset-bottom));


### PR DESCRIPTION
# Description

There was an issue with content overflowing the `DialogFooter` because it had a `z-index` of 1, which was introduced [here](https://github.com/TicketSwap/solar/pull/59). Removing it solves the issues and does not break any other examples, including `ContentTransition`.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Check out this branch
- Create this reproducible example:
```jsx
<BasicDialog>
  <DateInput
    id="example"
    label="Date"
    months={months}
    onChange={date => console.log(date)}
    dayInputProps={{
      placeholder: 'Day',
      label: 'Day',
    }}
    yearInputProps={{
      placeholder: 'Year',
      label: 'Year',
    }}
  />
</BasicDialog>
```
- `$ yarn dev`

## Screenshots
**Before**
<img width="554" alt="Screenshot 2022-03-01 at 15 13 56" src="https://user-images.githubusercontent.com/1096800/156187465-2f6f3e50-c90b-4f56-aaf4-9f250f026e7f.png">

**After**
<img width="584" alt="Screenshot 2022-03-01 at 15 14 11" src="https://user-images.githubusercontent.com/1096800/156187485-6d5a4e26-4238-4f7c-8172-c4aa43f59d47.png">

## To be notified
@TicketSwap/frontend 

## Links
https://developer.mozilla.org/en-US/docs/Web/CSS/z-index