### PR TITLE
ci(ci.yml): prevent CI from running in some situations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,14 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, ready_for_review, synchronize]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: |
+        !contains(github.event.head_commit.message, '[SKIP TESTS]') &&
+        github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,6 +30,9 @@ jobs:
 
   semantic_commits:
     runs-on: ubuntu-latest
+    if: |
+        !contains(github.event.head_commit.message, '[SKIP TESTS]') &&
+        github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,7 +44,10 @@ jobs:
   semantic_release:
     runs-on: ubuntu-latest
     needs: [tests]
-    if: github.ref == 'refs/heads/main'
+    if: |
+        github.ref == 'refs/heads/main' &&
+        !contains(github.event.head_commit.message, '[SKIP TESTS]') &&
+        github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

When a PR is a draft the CI should not run. It should only run when it's ready for review.

## Changes

- Used the same settings for Sirius in Solar

## How to test

- CI should not run if you create a draft PR
