### PR TITLE
fix(datePicker): fixing year range for custom timeframe

### DIFF
--- a/src/components/DatePicker/index.stories.tsx
+++ b/src/components/DatePicker/index.stories.tsx
@@ -109,7 +109,7 @@ export const All = () => {
 
 All.storyName = 'All dates'
 
-export const WithTimeRange = () => {
+export const WithDateRange = () => {
   const [date, setDate] = useState(null)
 
   return (
@@ -118,7 +118,7 @@ export const WithTimeRange = () => {
       timeFrame={TimeFrame.custom}
       dateRange={{
         start: new Date(2023, 2, 12),
-        end: new Date(2023, 4, 20),
+        end: new Date(2025, 4, 20),
       }}
       monthLabel="Month"
       yearLabel="Year"
@@ -129,7 +129,7 @@ export const WithTimeRange = () => {
   )
 }
 
-WithTimeRange.storyName = 'With a time range'
+WithDateRange.storyName = 'With a date range'
 
 export const WithTitle = () => {
   const [date, setDate] = useState(null)

--- a/src/utils/dates/index.ts
+++ b/src/utils/dates/index.ts
@@ -84,7 +84,7 @@ const getYears = ({ timeFrame, range, yearOfReference }: YearParams) => {
   }
 
   if (timeFrame === TimeFrame.custom) {
-    return generateYears(yearOfReference - range, yearOfReference)
+    return generateYears(yearOfReference, yearOfReference + range)
   }
 
   return generateYears(yearOfReference, yearOfReference + range)


### PR DESCRIPTION
# Description
A bug was spotted where the years shown in the select of the `datePicker` component were incorrect. 

## Changes

- [x] Updated the `generateYears` function

## How to test

- Checkout this branch
- `$ yarn run storybook`
- Check out the DatePicker story with date range 
- Play with the year range in the code
- Make sure the year select is showing the correct years

## Links
Fixes https://ticketswap.atlassian.net/browse/GIN-1986
