### PR TITLE
Cancel entering animation on unmount

### DIFF
--- a/src/components/ContentTransition/index.stories.tsx
+++ b/src/components/ContentTransition/index.stories.tsx
@@ -97,7 +97,13 @@ const Signup = (props: {
   </DialogBody>
 )
 
-const SignupEmail = ({}: { title: string; back: string }) => (
+const SignupEmail = (props: {
+  title: string
+  back: string
+  showSuccessView: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void
+}) => (
   <>
     <DialogBody>
       <div>
@@ -108,11 +114,23 @@ const SignupEmail = ({}: { title: string; back: string }) => (
       </div>
     </DialogBody>
     <DialogFooter>
-      <Button variant={ButtonVariant.success} fullWidth>
+      <Button
+        variant={ButtonVariant.success}
+        fullWidth
+        onClick={props.showSuccessView}
+      >
         Sign up
       </Button>
     </DialogFooter>
   </>
+)
+
+const SuccessView = ({}: { title: string; back: string }) => (
+  <DialogBody>
+    <div>
+      <p>Signup successful!</p>
+    </div>
+  </DialogBody>
 )
 
 function Dialog() {
@@ -167,7 +185,9 @@ function Dialog() {
             key="signupEmail"
             title="Sign up with email"
             back="signup"
+            showSuccessView={() => setActiveView('success')}
           />
+          <SuccessView key="success" title="Success" back="signupEmail" />
         </ContentTransition>
       </DialogWindow>
     </>

--- a/src/components/ContentTransition/index.tsx
+++ b/src/components/ContentTransition/index.tsx
@@ -1,8 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 import styled from '@emotion/styled'
 import { easing } from '../../theme'
-import { usePrevious, useTransition } from '../../hooks'
-import { TransitionState } from '../../hooks/useTransition'
+import { TransitionState, usePrevious, useTransition } from '../../hooks'
 
 const duration = 400
 

--- a/src/hooks/useTransition/index.ts
+++ b/src/hooks/useTransition/index.ts
@@ -71,7 +71,11 @@ export const useTransition = ({
   }, [onExiting, handleExited, timeout])
 
   useIsomorphicLayoutEffect(() => {
-    if (transitioning) return
+    if (state === TransitionState.EXITING) return
+
+    if (!on && typeof enteringTimerID.current !== 'undefined') {
+      clearTimeout(enteringTimerID.current)
+    }
 
     if (on && !prevOn) {
       setMounted(true)
@@ -84,7 +88,7 @@ export const useTransition = ({
     if (prevOn && !on) {
       exitingTimerID.current = handleExiting()
     }
-  }, [on, prevOn, handleEntering, transitioning, handleExiting])
+  }, [on, prevOn, handleEntering, transitioning, handleExiting, state])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
# Description
This PR fixes https://github.com/TicketSwap/solar/issues/1376
The bug was caused by not calling the handleExiting when a transition was in progress. When a component was still entering the view and then unmounted it wouldn't call the exit functions.

## Changes
- [x] Cancel the entering timeout/animation when a component is unmounted.

## How to test
1. Go to storybook
2. In the content transition story follow these views: `signup` > `signup with email` > `signup button` .
3. You should see the success view
4. Now click the back chevron twice in rapid succession.
5. You don't see the thing you see in screen recording AND there is no weird flickering on the dialog (that's why the transitioning check was there in the first place)

## Screenshots

OLD: 

https://user-images.githubusercontent.com/22071649/157454456-0f79064d-0ae4-45c3-8fca-827690deea53.mov


NEW: 

https://user-images.githubusercontent.com/22071649/157454474-ce5afcbf-f135-4d8f-945b-dce2a58232a7.mov



