### PR TITLE
feat(basebutton): add small baseButton size

### DIFF
--- a/src/components/BaseButton/index.stories.tsx
+++ b/src/components/BaseButton/index.stories.tsx
@@ -1,41 +1,67 @@
 import React from 'react'
-import { BaseButton, ButtonVariant } from './'
+import { BaseButton, BaseButtonSize, ButtonVariant } from './'
 import { File } from '../../icons'
+import styled from '@emotion/styled'
+
+const ButtonWrapper = styled.div`
+  button {
+    display: block;
+    margin-bottom: 16px;
+  }
+`
 
 export const Basic = () => (
-  <BaseButton id="baseButton" onClick={() => alert('Clicked')}>
-    Default
-  </BaseButton>
+  <ButtonWrapper>
+    <BaseButton onClick={() => alert('Clicked')}>Default medium</BaseButton>
+    <BaseButton size={BaseButtonSize.small} onClick={() => alert('Clicked')}>
+      Default small
+    </BaseButton>
+  </ButtonWrapper>
 )
 
 export const WithIcon = () => (
-  <BaseButton id="baseButton" leftAdornment={<File size={24} />}>
-    View example
-  </BaseButton>
+  <ButtonWrapper>
+    <BaseButton leftAdornment={<File size={24} />}>View example</BaseButton>
+    <BaseButton size={BaseButtonSize.small} leftAdornment={<File size={16} />}>
+      View example
+    </BaseButton>
+  </ButtonWrapper>
 )
 
 export const Success = () => (
-  <BaseButton id="baseButton" variant={ButtonVariant.success}>
-    Success
-  </BaseButton>
+  <ButtonWrapper>
+    <BaseButton variant={ButtonVariant.success}>Success</BaseButton>
+    <BaseButton size={BaseButtonSize.small} variant={ButtonVariant.success}>
+      Success
+    </BaseButton>
+  </ButtonWrapper>
 )
 
 export const Warning = () => (
-  <BaseButton id="baseButton" variant={ButtonVariant.warning}>
-    Warning
-  </BaseButton>
+  <ButtonWrapper>
+    <BaseButton variant={ButtonVariant.warning}>Warning</BaseButton>
+    <BaseButton size={BaseButtonSize.small} variant={ButtonVariant.warning}>
+      Warning
+    </BaseButton>
+  </ButtonWrapper>
 )
 
 export const Danger = () => (
-  <BaseButton id="baseButton" variant={ButtonVariant.danger}>
-    Danger
-  </BaseButton>
+  <ButtonWrapper>
+    <BaseButton variant={ButtonVariant.danger}>Danger</BaseButton>
+    <BaseButton size={BaseButtonSize.small} variant={ButtonVariant.danger}>
+      Danger
+    </BaseButton>
+  </ButtonWrapper>
 )
 
 export const Disabled = () => (
-  <BaseButton id="baseButton" disabled>
-    Disabled
-  </BaseButton>
+  <ButtonWrapper>
+    <BaseButton disabled>Disabled</BaseButton>
+    <BaseButton size={BaseButtonSize.small} disabled>
+      Disabled
+    </BaseButton>
+  </ButtonWrapper>
 )
 
 export default {

--- a/src/components/BaseButton/index.test.tsx
+++ b/src/components/BaseButton/index.test.tsx
@@ -1,32 +1,41 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { matchers } from '@emotion/jest'
-import { BaseButton, ButtonVariant } from '.'
-import { color } from '../../theme'
+import { BaseButton, BaseButtonSize, ButtonVariant } from '.'
+import { color, fontSize } from '../../theme'
 
 expect.extend(matchers)
 
 describe('BaseButton', () => {
   it('renders without crashing and calls action handlers', () => {
     const action = jest.fn()
-    const { container, getByText } = render(
-      <BaseButton onClick={action}>Default</BaseButton>
-    )
-    expect(container.firstChild).toBeInTheDocument()
-    fireEvent.click(getByText(/Default/i))
+    render(<BaseButton onClick={action}>Default</BaseButton>)
+    fireEvent.click(screen.getByText('Default'))
     expect(action).toHaveBeenCalledTimes(1)
   })
 
-  it('renders the varriant prop correctly', () => {
-    const { getByText } = render(
-      <BaseButton variant={ButtonVariant.danger}>Danger</BaseButton>
-    )
+  it('renders the variant prop correctly', () => {
+    render(<BaseButton variant={ButtonVariant.danger}>Danger</BaseButton>)
 
-    expect(getByText(/Danger/i)).toHaveStyleRule('color', color.failure)
+    expect(screen.getByText('Danger')).toHaveStyleRule('color', color.failure)
+  })
+
+  it('renders the small size correctly', () => {
+    render(<BaseButton size={BaseButtonSize.small}>Small</BaseButton>)
+    expect(screen.getByText('Small')).toHaveStyleRule('font-size', fontSize[14])
+  })
+
+  it('renders the medium size correctly', () => {
+    render(<BaseButton>Medium</BaseButton>)
+
+    expect(screen.getByText('Medium')).toHaveStyleRule(
+      'font-size',
+      fontSize[16]
+    )
   })
 
   it('can render with a left adornment', () => {
-    const { getByText } = render(
+    render(
       <BaseButton
         leftAdornment={
           <span role="img" aria-label="fire">
@@ -38,6 +47,6 @@ describe('BaseButton', () => {
       </BaseButton>
     )
 
-    expect(getByText(/🔥/i)).toBeInTheDocument()
+    expect(screen.getByText('🔥')).toBeInTheDocument()
   })
 })

--- a/src/components/BaseButton/index.tsx
+++ b/src/components/BaseButton/index.tsx
@@ -1,7 +1,8 @@
 import React, { ReactNode } from 'react'
 import styled from '@emotion/styled'
-import { space, color, fontWeight, radius, device } from '../../theme'
+import { space, color, fontWeight, radius, device, fontSize } from '../../theme'
 import { baseTextStyles } from '../Text'
+import { css } from '@emotion/react'
 
 export enum ButtonVariant {
   info = 'info',
@@ -10,10 +11,16 @@ export enum ButtonVariant {
   danger = 'danger',
 }
 
+export enum BaseButtonSize {
+  medium = 'medium',
+  small = 'small',
+}
+
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   leftAdornment?: ReactNode
   variant?: ButtonVariant
   disabled?: boolean
+  size?: BaseButtonSize
 }
 
 const StyledButton = styled.button<ButtonProps>`
@@ -32,6 +39,17 @@ const StyledButton = styled.button<ButtonProps>`
       : color.info};
   font-weight: ${fontWeight.semiBold};
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+
+  ${({ size }) =>
+    size === BaseButtonSize.small &&
+    css`
+      font-size: ${fontSize[14]};
+      font-weight: ${fontWeight.regular};
+
+      @media ${device.tablet} {
+        font-size: ${fontSize[16]};
+      }
+    `}
 
   &:hover,
   &:focus {
@@ -77,10 +95,10 @@ const Adornment = styled.span`
 
 const BaseButton: React.FC<ButtonProps> = React.forwardRef(
   (
-    { children, leftAdornment, ...props },
+    { children, leftAdornment, size = BaseButtonSize.medium, ...props },
     ref: React.Ref<HTMLButtonElement>
   ) => (
-    <StyledButton ref={ref} {...props}>
+    <StyledButton ref={ref} size={size} {...props}>
       {leftAdornment && <Adornment>{leftAdornment}</Adornment>}
       {children}
     </StyledButton>


### PR DESCRIPTION
# Description
Adds a small variant of the base button. Props are the same as we have on the button component, using `small` and `medium` sizes.

<img width="331" alt="image" src="https://user-images.githubusercontent.com/22071649/157686779-d791ae29-de81-48e3-bfdf-fe7145150499.png">


Fixes https://github.com/TicketSwap/solar/issues/1368