### PR TITLE
Adjust accordion text color to foreground

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -50,6 +50,7 @@ const Button = styled<React.FC<AccordionButtonProps>>(Reach.AccordionButton)`
   padding-top: ${space[12]};
   padding-bottom: ${space[12]};
   text-align: left;
+  color: ${color.foreground};
 
   &[data-disabled] {
     cursor: not-allowed;


### PR DESCRIPTION
# Description
Adjust the text color of the accordion from blue to black.

<img width="672" alt="image" src="https://user-images.githubusercontent.com/22071649/159715068-dd76a912-2088-4178-a989-f270763171a9.png">
