### PR TITLE
fix(datePicker): fixing close modal on click outside

### DIFF
--- a/src/components/DatePicker/CalendarDialog.tsx
+++ b/src/components/DatePicker/CalendarDialog.tsx
@@ -158,10 +158,9 @@ const CalendarDialog = ({
     <Dialog on={isOpen}>
       {({ getWindowProps }) => (
         <DialogWindow
-          {...getWindowProps({
-            onClick: close,
-            onEscKeyDown: close,
-          })}
+          {...getWindowProps()}
+          onClick={close}
+          onEscKeyDown={close}
         >
           <DialogHeader>
             {title}


### PR DESCRIPTION
# Description
See title.

## Changes
Extracted `onClick` and `onEscKeyDown` outside of the `getWindowProps` so closing the dialog work on click outside  

## How to test

- Checkout this branch
- run `$ yarn storybook`
- go to DatePicker - any stories
- click on the datePicker to open the dialog 
- close it by clicking outside the dialog 

## Links
Fix [#5919](https://github.com/TicketSwap/sirius/issues/5919)
