### PR TITLE
fix: use correct colors for tooltip

### DIFF
--- a/src/components/Tooltip/index.stories.tsx
+++ b/src/components/Tooltip/index.stories.tsx
@@ -1,21 +1,28 @@
+import styled from '@emotion/styled'
 import React from 'react'
 import { Tooltip } from '.'
+import { space } from '../../theme'
+import { Button } from '../Button'
 
 export default {
   title: 'Components/Data Display/Tooltip',
 }
 
+const Grid = styled.div`
+  display: flex;
+  gap: ${space[16]};
+`
+
 export const Basic = () => (
-  <>
+  <Grid>
     <Tooltip label="Lorem ipsum">
-      <button style={{ fontSize: 25 }}>
-        <span aria-hidden>🔔</span>
-      </button>
+      <Button>Enable</Button>
     </Tooltip>
+
     <Tooltip label="Dolor sit amet">
       <button style={{ fontSize: 25 }}>
         <span aria-hidden>🔔</span>
       </button>
     </Tooltip>
-  </>
+  </Grid>
 )

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import styled from '@emotion/styled'
 import { Portal } from '../Portal'
-import { radius, color, space } from '../../theme'
+import { radius, color, space, fontSize } from '../../theme'
 import { Global, css } from '@emotion/react'
 import { useTooltip, TooltipPopup, TooltipPopupProps } from '@reach/tooltip'
 
@@ -37,14 +37,15 @@ const centered = (
 const Popup = styled<React.FC<TooltipPopupProps>>(TooltipPopup)`
   pointer-events: none;
   position: absolute;
+  margin-top: 4px;
   padding: ${space[8]} ${space[12]};
   box-shadow: 2px 2px 10px hsla(0, 0%, 0%, 0.1);
   white-space: nowrap;
-  font-size: inherit;
+  font-size: ${fontSize[16]};
   color: ${color.invertedForeground};
   border: 0;
   border-radius: ${radius.md};
-  background: ${color.foregroundMuted};
+  background: ${color.invertedBackground};
 `
 
 interface TriangleStyleProps {
@@ -57,7 +58,8 @@ const Triangle = styled.div<TriangleStyleProps>`
   height: 0;
   border-left: ${props => props.size || 10}px solid transparent;
   border-right: ${props => props.size || 10}px solid transparent;
-  border-bottom: ${props => props.size || 10}px solid ${color.foregroundMuted};
+  border-bottom: ${props => props.size || 10}px solid
+    ${color.invertedBackground};
 `
 
 export const Tooltip = ({


### PR DESCRIPTION
# Description

The colors of the tooltip weren't using the correct colors, so I've added proper background and foreground colors. Also scaled-down the tooltip, because it was a little too big imo.

@Marruk could you give feedback?

## How to test

- Checkout this branch
- `$ yarn storybook`
- Search for Tooltip
- Verify it's working

## Screenshots

Before
![Screenshot 2022-03-31 at 14 58 33](https://user-images.githubusercontent.com/14276144/161060177-a05f9d6c-3db8-4330-b8d0-82469f7a2344.png)

After

![Screenshot 2022-03-31 at 18 22 06](https://user-images.githubusercontent.com/14276144/161103435-f670b51b-b5b4-421c-b2d7-f3587170ba62.png)
![Screenshot 2022-03-31 at 18 22 23](https://user-images.githubusercontent.com/14276144/161103444-3d870952-255e-48cb-9940-7c1e5cf28537.png)


