### PR TITLE
Use an underline to highlight the action on hover / focus

### DIFF
--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -111,7 +111,7 @@ const Message = styled.p`
 const Action = styled.button`
   ${textColor};
   outline: 0;
-  font-weight: ${fontWeight.bold};
+  font-weight: ${fontWeight.semiBold};
   flex-shrink: 0;
   transition: color ${transition};
   margin-top: ${6 / 16}rem;
@@ -126,14 +126,7 @@ const Action = styled.button`
 
   &:hover,
   &:focus {
-    color: ${props =>
-      props.variant === AlertVariant.success
-        ? color.onSuccess
-        : props.variant === AlertVariant.error
-        ? color.onFailure
-        : props.variant === AlertVariant.warning
-        ? color.onWarning
-        : color.onInfo};
+    text-decoration: underline;
   }
 `
 


### PR DESCRIPTION
# Description
Instead of a lighter color (which is not available in the new color scheme yet) we now use a `text-decoration: underline` to temporarily solve the issue of the missing colors. 

A brief summary of the changes in this pull request.

## Changes

- [x] Change colors to underline on hover / focus in alert
- [x] Change the font-size of the action so it's inline with the rest of the buttons

## How to test

- Checkout this branch
- `$ yarn && yarn storybook`
- Go to `<Alert />` under `Feedback` in storybook and confirm the one with actions displays an underline and has the correct font-size.

## Screenshots

<img width="493" alt="image" src="https://user-images.githubusercontent.com/12168698/161223650-36fa9731-6af0-41df-96e1-34f09418d3ee.png">

## To be notified

@TicketSwap/frontend 



