### PR TITLE
fix(pill): change text color to be less strong

### DIFF
--- a/src/components/Pill/index.tsx
+++ b/src/components/Pill/index.tsx
@@ -29,7 +29,7 @@ export const Container = styled.span<PillProps>`
       : p.variant === 'warning'
       ? color.onWarning
       : p.variant === 'disabled'
-      ? color.onInactive
+      ? color.inactive
       : color.onAction};
   background-color: ${p =>
     p.variant === 'danger'


### PR DESCRIPTION
# Description

Change text color form `onInactive` to `inactive`. Will also be tweaked in the future by Mark (designer) most likely.

## Changes

- [x] Change color

## How to test

- Checkout this branch
- `$ yarn && yarn storybook`
- Go to `<Pill />` and confirm the pill has less strong text color.

## Screenshots

<img width="108" alt="image" src="https://user-images.githubusercontent.com/12168698/161225195-2290e8ec-d72e-48eb-8485-eb6d8973c057.png">
## To be notified

@TicketSwap/frontend 
