### PR TITLE
Update userEvent to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/react-hooks": "^7.0.2",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.4",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.14",
     "@typescript-eslint/eslint-plugin": "^5.16.0",

--- a/src/components/Accordion/index.test.tsx
+++ b/src/components/Accordion/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { Accordion, AccordionItem, AccordionButton, AccordionPanel } from '.'
 
 describe('Accordion', () => {

--- a/src/components/Alert/index.test.tsx
+++ b/src/components/Alert/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { Alert, AlertVariant } from '.'
 import { color } from '../../theme'

--- a/src/components/Avatar/index.test.tsx
+++ b/src/components/Avatar/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Avatar } from './'
 
 describe('Avatar', () => {

--- a/src/components/Banner/index.test.tsx
+++ b/src/components/Banner/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Banner } from './'
 import { H2 } from '../Heading'
 

--- a/src/components/BaseButton/index.test.tsx
+++ b/src/components/BaseButton/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { BaseButton, BaseButtonSize, ButtonVariant } from '.'
 import { color, fontSize } from '../../theme'

--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { Button, ButtonVariant } from '.'
 import { color } from '../../theme'

--- a/src/components/Card/index.test.tsx
+++ b/src/components/Card/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Card } from '.'
 
 describe('Card', () => {

--- a/src/components/CardCarousel/index.test.tsx
+++ b/src/components/CardCarousel/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Card } from '../Card'
 import { CardCarousel } from '.'
 

--- a/src/components/Checkbox/index.test.tsx
+++ b/src/components/Checkbox/index.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Checkbox } from './'
-import { fireEvent, render } from '@testing-library/react'
-
+import { fireEvent, render } from '../../../test/test.utils'
 describe('Checkbox', () => {
   it('renders without crashing', () => {
     const { container } = render(

--- a/src/components/Collapsible/index.test.tsx
+++ b/src/components/Collapsible/index.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Collapsible } from './index'
-import { fireEvent, render } from '@testing-library/react'
-
+import { fireEvent, render } from '../../../test/test.utils'
 describe('Collapsible', () => {
   it('renders without crashing', () => {
     const { container } = render(

--- a/src/components/Combobox/index.test.tsx
+++ b/src/components/Combobox/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { Combobox } from './'
 
 const countries = [

--- a/src/components/ContentDialog/index.test.tsx
+++ b/src/components/ContentDialog/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, screen, render } from '@testing-library/react'
+import { fireEvent, screen, render } from '../../../test/test.utils'
 import { ContentDialog } from '.'
 import { H1 } from '../Heading'
 

--- a/src/components/ContentTransition/index.test.tsx
+++ b/src/components/ContentTransition/index.test.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react'
 import { useState } from 'react'
-import { screen, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen, render } from '../../../test/test.utils'
 import { ContentTransition } from './'
 
 const delay = ms => new Promise(res => setTimeout(res, ms))
@@ -37,9 +36,9 @@ describe('ContentTransition', () => {
 
   describe('when the view changes', () => {
     it('renders the new view', async () => {
-      render(<TransitionExample />)
+      const { user } = render(<TransitionExample />)
 
-      userEvent.click(screen.getByRole('button', { name: /go to second/i }))
+      await user.click(screen.getByRole('button', { name: /go to second/i }))
 
       const secondView = await screen.findByText('Second view')
 
@@ -48,13 +47,13 @@ describe('ContentTransition', () => {
 
     describe('and the view changes again', () => {
       it('renders the initial view', async () => {
-        render(<TransitionExample />)
+        const { user } = render(<TransitionExample />)
 
-        userEvent.click(screen.getByRole('button', { name: /go to second/i }))
+        await user.click(screen.getByRole('button', { name: /go to second/i }))
 
         await screen.findByText('Second view')
 
-        userEvent.click(screen.getByRole('button', { name: /go to first/i }))
+        await user.click(screen.getByRole('button', { name: /go to first/i }))
 
         const firstView = await screen.findByText('First view')
 
@@ -66,9 +65,11 @@ describe('ContentTransition', () => {
       it('invokes the callback', async () => {
         const callback = jest.fn()
 
-        render(<TransitionExample callback={view => callback(view)} />)
+        const { user } = render(
+          <TransitionExample callback={view => callback(view)} />
+        )
 
-        userEvent.click(screen.getByRole('button', { name: /go to second/i }))
+        await user.click(screen.getByRole('button', { name: /go to second/i }))
 
         await screen.findByText('Second view')
 
@@ -82,7 +83,7 @@ describe('ContentTransition', () => {
         it('does not cancel async tasks', async () => {
           const callback = jest.fn()
 
-          const { unmount } = render(
+          const { unmount, user } = render(
             <TransitionExample
               callback={async children => {
                 await delay(10)
@@ -91,7 +92,9 @@ describe('ContentTransition', () => {
             />
           )
 
-          userEvent.click(screen.getByRole('button', { name: /go to second/i }))
+          await user.click(
+            screen.getByRole('button', { name: /go to second/i })
+          )
 
           unmount()
 

--- a/src/components/Cover/index.test.tsx
+++ b/src/components/Cover/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Cover } from '.'
 import { H1 } from '../Heading'
 

--- a/src/components/DateInput/index.test.tsx
+++ b/src/components/DateInput/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { DateInput } from '.'
 
 const months = [

--- a/src/components/DatePicker/CalendarDialog.test.tsx
+++ b/src/components/DatePicker/CalendarDialog.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { screen, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen, render } from '../../../test/test.utils'
 import CalendarDialog from './CalendarDialog'
 import { TimeFrame } from '../../utils/dates'
 
@@ -15,7 +14,7 @@ describe('CalendarDialog', () => {
       const close = jest.fn()
       const date = new Date(2020, 1, 1)
 
-      render(
+      const { user } = render(
         <CalendarDialog
           date={date}
           title="Pick a date"
@@ -32,7 +31,7 @@ describe('CalendarDialog', () => {
 
       await dialogIsOpen()
 
-      userEvent.click(
+      await user.click(
         screen.getByRole('button', {
           name: /closealt/i,
         })
@@ -212,7 +211,7 @@ describe('CalendarDialog', () => {
     it('displays the new month', async () => {
       const date = new Date(2020, 1, 1)
 
-      render(
+      const { user } = render(
         <CalendarDialog
           date={date}
           title="Pick a date"
@@ -229,11 +228,13 @@ describe('CalendarDialog', () => {
 
       await dialogIsOpen()
 
-      userEvent.click(screen.getByRole('textbox', { name: /month arrowdown/i }))
+      await user.click(
+        screen.getByRole('textbox', { name: /month arrowdown/i })
+      )
 
       await dropdownIsOpen()
 
-      userEvent.click(
+      await user.click(
         screen.getByRole('option', {
           name: /march/i,
         })
@@ -251,7 +252,7 @@ describe('CalendarDialog', () => {
     it('displays the new year', async () => {
       const date = new Date(2020, 1, 1)
 
-      render(
+      const { user } = render(
         <CalendarDialog
           date={date}
           title="Pick a date"
@@ -268,11 +269,11 @@ describe('CalendarDialog', () => {
 
       await dialogIsOpen()
 
-      userEvent.click(screen.getByRole('textbox', { name: /year arrowdown/i }))
+      await user.click(screen.getByRole('textbox', { name: /year arrowdown/i }))
 
       await dropdownIsOpen()
 
-      userEvent.click(
+      await user.click(
         screen.getByRole('option', {
           name: /2023/i,
         })
@@ -290,7 +291,7 @@ describe('CalendarDialog', () => {
     it('saves the selected day', async () => {
       const date = new Date(2020, 1, 1)
 
-      render(
+      const { user } = render(
         <CalendarDialog
           date={date}
           title="Pick a date"
@@ -307,7 +308,7 @@ describe('CalendarDialog', () => {
 
       await dialogIsOpen()
 
-      userEvent.click(screen.getByRole('button', { name: '4' }))
+      await user.click(screen.getByRole('button', { name: '4' }))
 
       expect(
         screen.getByRole('button', {

--- a/src/components/DatePicker/Day.test.tsx
+++ b/src/components/DatePicker/Day.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { screen, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen, render } from '../../../test/test.utils'
 import Day from './Day'
 
 describe('Day', () => {
@@ -18,13 +17,15 @@ describe('Day', () => {
     })
 
     describe('and the day is selected', () => {
-      it('saves the selected day', () => {
+      it('saves the selected day', async () => {
         const date = new Date(2050, 1, 1)
         const onSelect = jest.fn()
 
-        render(<Day date={date} isSelected={false} onSelect={onSelect} />)
+        const { user } = render(
+          <Day date={date} isSelected={false} onSelect={onSelect} />
+        )
 
-        userEvent.click(
+        await user.click(
           screen.getByRole('button', {
             name: /1/i,
           })
@@ -68,11 +69,11 @@ describe('Day', () => {
     })
 
     describe('and the day is selected', () => {
-      it('does not save the selected day', () => {
+      it('does not save the selected day', async () => {
         const date = new Date(2000, 1, 1)
         const onSelect = jest.fn()
 
-        render(
+        const { user } = render(
           <Day
             date={date}
             isSelected={false}
@@ -81,7 +82,7 @@ describe('Day', () => {
           />
         )
 
-        userEvent.click(
+        await user.click(
           screen.getByRole('button', {
             name: /1/i,
           })

--- a/src/components/DatePicker/index.test.tsx
+++ b/src/components/DatePicker/index.test.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-import { screen, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen, render } from '../../../test/test.utils'
 import { DatePicker, TimeFrame } from '.'
 
 jest.mock('../../hooks/useOnClickOutside')
@@ -67,12 +66,12 @@ describe('DatePicker', () => {
           </>
         )
       }
-      render(<TestScenario />)
+      const { user } = render(<TestScenario />)
 
       expect(screen.getByText(/Feb 1, 2020/i)).toBeInTheDocument()
 
       const resetButton = screen.getByLabelText('Clear')
-      userEvent.click(resetButton)
+      await user.click(resetButton)
 
       expect(screen.getByText(/from/i)).toBeInTheDocument()
     })
@@ -80,7 +79,7 @@ describe('DatePicker', () => {
 
   describe('when open', () => {
     it('renders the calendar', async () => {
-      render(
+      const { user } = render(
         <DatePicker
           date={new Date(2020, 1, 1)}
           placeholder="From"
@@ -94,7 +93,7 @@ describe('DatePicker', () => {
         />
       )
 
-      userEvent.click(screen.getByText(/Feb 1, 2020/i))
+      await user.click(screen.getByText(/Feb 1, 2020/i))
 
       const calendarTitle = await screen.findByText(/pick a date/i)
 
@@ -114,7 +113,7 @@ describe('DatePicker', () => {
       it('calls the onChange with the selected date', async () => {
         const onChange = jest.fn()
 
-        render(
+        const { user } = render(
           <DatePicker
             date={null}
             placeholder="From"
@@ -128,11 +127,15 @@ describe('DatePicker', () => {
           />
         )
 
-        userEvent.click(screen.getByText(/From/i))
+        await user.click(
+          screen.getByRole('button', {
+            name: /from/i,
+          })
+        )
 
         await screen.findByText(/pick a date/i)
 
-        userEvent.click(screen.getByText(/25/i))
+        await user.click(screen.getByText(/25/i))
 
         expect(onChange).toHaveBeenCalledWith(new Date(2020, 10, 25))
       })
@@ -158,15 +161,15 @@ describe('DatePicker', () => {
           )
         }
 
-        render(<TestScenario />)
+        const { user } = render(<TestScenario />)
 
-        userEvent.click(screen.getByText(/From/i))
+        await user.click(screen.getByText(/From/i))
 
         await screen.findByText(/pick a date/i)
 
-        userEvent.click(screen.getByText(/25/i))
+        await user.click(screen.getByText(/25/i))
 
-        userEvent.click(screen.getByText(/nov 25, 2020/i))
+        await user.click(screen.getByText(/nov 25, 2020/i))
 
         expect(
           screen.getByRole('button', {
@@ -248,25 +251,25 @@ describe('DatePicker', () => {
         )
       }
 
-      render(<TestScenario />)
+      const { user } = render(<TestScenario />)
 
-      userEvent.click(screen.getByText(/From/i))
+      await user.click(screen.getByText(/From/i))
 
       await screen.findByText(/pick a date/i)
 
-      userEvent.click(screen.getByText(/year/i))
+      await user.click(screen.getByText(/year/i))
 
-      userEvent.click(screen.getByText(/2022/i))
+      await user.click(screen.getByText(/2022/i))
 
-      userEvent.click(screen.getByText(/month/i))
+      await user.click(screen.getByText(/month/i))
 
-      userEvent.click(screen.getByText(/january/i))
+      await user.click(screen.getByText(/january/i))
 
-      userEvent.click(screen.getByText(/25/i))
+      await user.click(screen.getByText(/25/i))
 
       expect(screen.getAllByText(/jan 25, 2022/i)).toHaveLength(2)
 
-      userEvent.click(screen.getAllByText(/jan 25, 2022/i)[1])
+      await user.click(screen.getAllByText(/jan 25, 2022/i)[1])
 
       expect(
         screen.getByRole('button', {

--- a/src/components/Dialog/index.test.tsx
+++ b/src/components/Dialog/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { screen, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen, render } from '../../../test/test.utils'
 import { Button, ButtonVariant } from '../Button'
 import { Close } from '../../icons'
 import {
@@ -64,9 +63,9 @@ describe('Dialog', () => {
     expect(getByText(/show dialog/i)).toBeInTheDocument()
   })
 
-  it('renders overlay, window, header, body and footer when clicking the toggle', () => {
-    const { getByText, getByTestId } = render(<MyDialog>Body</MyDialog>)
-    userEvent.click(getByText(/show dialog/i))
+  it('renders overlay, window, header, body and footer when clicking the toggle', async () => {
+    const { getByText, getByTestId, user } = render(<MyDialog>Body</MyDialog>)
+    await user.click(getByText(/show dialog/i))
     expect(getByTestId('dialog-overlay')).toBeInTheDocument()
     expect(getByTestId('dialog-content')).toBeInTheDocument()
     expect(getByText(/dialog title/i)).toBeInTheDocument()
@@ -74,30 +73,30 @@ describe('Dialog', () => {
     expect(getByText(/discard/i)).toBeInTheDocument()
   })
 
-  it('closes the dialog when clicking the overlay', () => {
-    const { getByText, getByTestId, queryByTestId } = render(
+  it('closes the dialog when clicking the overlay', async () => {
+    const { getByText, getByTestId, queryByTestId, user } = render(
       <MyDialog>Body</MyDialog>
     )
-    userEvent.click(getByText(/show dialog/i))
-    userEvent.click(getByTestId('dialog-overlay'))
+    await user.click(getByText(/show dialog/i))
+    await user.click(getByTestId('dialog-overlay'))
     expect(queryByTestId('dialog-content')).toBeNull()
   })
 
-  it('closes the dialog when clicking the close-button', () => {
-    const { getByText, getByTestId, queryByTestId } = render(
+  it('closes the dialog when clicking the close-button', async () => {
+    const { getByText, getByTestId, queryByTestId, user } = render(
       <MyDialog>Body</MyDialog>
     )
-    userEvent.click(getByText(/show dialog/i))
-    userEvent.click(getByTestId('close-button'))
+    await user.click(getByText(/show dialog/i))
+    await user.click(getByTestId('close-button'))
     expect(queryByTestId('dialog-content')).toBeNull()
   })
 
   describe('useDialog', () => {
     describe('when the toggle is pressed', () => {
       it('opens the dialog', async () => {
-        render(<HooksDialog />)
+        const { user } = render(<HooksDialog />)
 
-        userEvent.click(screen.getByRole('button', { name: /show dialog/i }))
+        await user.click(screen.getByRole('button', { name: /show dialog/i }))
 
         const title = await screen.findByText(/Dialog title/i)
         const body = await screen.findByText(/Body/i)
@@ -109,13 +108,13 @@ describe('Dialog', () => {
 
     describe('when the close button is pressed', () => {
       it('closes the dialog', async () => {
-        render(<HooksDialog />)
+        const { user } = render(<HooksDialog />)
 
-        userEvent.click(screen.getByRole('button', { name: /show dialog/i }))
+        await user.click(screen.getByRole('button', { name: /show dialog/i }))
 
         await screen.findByText(/Dialog title/i)
 
-        userEvent.click(screen.getByRole('button', { name: /close/i }))
+        await user.click(screen.getByRole('button', { name: /close/i }))
 
         expect(screen.queryByText(/Dialog title/i)).not.toBeInTheDocument()
         expect(screen.queryByText(/Body/i)).not.toBeInTheDocument()

--- a/src/components/Flag/index.test.tsx
+++ b/src/components/Flag/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Flag } from '.'
 
 describe('Flag', () => {

--- a/src/components/Image/index.test.tsx
+++ b/src/components/Image/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Image } from '.'
 import { matchers } from '@emotion/jest'
 

--- a/src/components/Input/index.test.tsx
+++ b/src/components/Input/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { Input } from './'
 import { space } from '../../theme'

--- a/src/components/MenuButton/index.test.tsx
+++ b/src/components/MenuButton/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Menu, MenuButton, MenuItem, MenuLink, MenuList } from './'
 
 const handleOnSelect = jest.fn()

--- a/src/components/MoneyInput/index.test.tsx
+++ b/src/components/MoneyInput/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { MoneyInput } from '.'
 
 const currencies = [

--- a/src/components/OnboardingDialog/index.test.tsx
+++ b/src/components/OnboardingDialog/index.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { StorybookDialog } from './index.stories'
-import { fireEvent, render } from '@testing-library/react'
-
+import { fireEvent, render } from '../../../test/test.utils'
 describe('OnboardingDialog', () => {
   it('renders without crashing', () => {
     const { container } = render(<StorybookDialog />)

--- a/src/components/OneTimeCodeInput/index.test.tsx
+++ b/src/components/OneTimeCodeInput/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { fireEvent, render, screen, waitFor } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { OneTimeCodeInput } from './'
 
@@ -56,7 +55,7 @@ describe('OneTimeCodeInput', () => {
 
   describe('when an onChange event is triggered', () => {
     it('handles the onChange event', async () => {
-      render(
+      const { user } = render(
         <OneTimeCodeInput
           id="OneTimeCodeInput"
           length={5}
@@ -65,7 +64,7 @@ describe('OneTimeCodeInput', () => {
         />
       )
 
-      userEvent.type(
+      await user.type(
         screen.getByRole('textbox', {
           name: /onetimecode input field 1/i,
         }),
@@ -129,7 +128,7 @@ describe('OneTimeCodeInput', () => {
   describe('when there is a navigation event', () => {
     describe('and it is an ArrowLeft', () => {
       it('moves left', async () => {
-        render(
+        const { user } = render(
           <OneTimeCodeInput
             id="OneTimeCodeInput"
             length={5}
@@ -138,16 +137,14 @@ describe('OneTimeCodeInput', () => {
           />
         )
 
-        userEvent.type(
+        await user.type(
           screen.getByRole('textbox', {
             name: /onetimecode input field 1/i,
           }),
           '75689'
         )
 
-        await fillOneTimeCode()
-
-        userEvent.type(
+        await user.type(
           screen.getByRole('textbox', {
             name: /onetimecode input field 5/i,
           }),
@@ -164,7 +161,7 @@ describe('OneTimeCodeInput', () => {
 
     describe('and it is an ArrowRight', () => {
       it('moves right', async () => {
-        render(
+        const { user } = render(
           <OneTimeCodeInput
             id="OneTimeCodeInput"
             length={5}
@@ -173,14 +170,14 @@ describe('OneTimeCodeInput', () => {
           />
         )
 
-        userEvent.type(
+        await user.type(
           screen.getByRole('textbox', {
             name: /onetimecode input field 1/i,
           }),
           '75689'
         )
 
-        userEvent.type(
+        await user.type(
           screen.getByRole('textbox', {
             name: /onetimecode input field 4/i,
           }),
@@ -198,7 +195,7 @@ describe('OneTimeCodeInput', () => {
     describe('and its a Backspace', () => {
       describe('and there is a value', () => {
         it('removes the value', async () => {
-          render(
+          const { user } = render(
             <OneTimeCodeInput
               id="OneTimeCodeInput"
               length={5}
@@ -207,14 +204,14 @@ describe('OneTimeCodeInput', () => {
             />
           )
 
-          userEvent.type(
+          await user.type(
             screen.getByRole('textbox', {
               name: /onetimecode input field 1/i,
             }),
             '75689'
           )
 
-          userEvent.type(
+          await user.type(
             screen.getByRole('textbox', {
               name: /onetimecode input field 5/i,
             }),
@@ -239,7 +236,7 @@ describe('OneTimeCodeInput', () => {
 
       describe('and there is no value', () => {
         it('moves focus to the previous input field', async () => {
-          render(
+          const { user } = render(
             <OneTimeCodeInput
               id="OneTimeCodeInput"
               length={5}
@@ -248,14 +245,14 @@ describe('OneTimeCodeInput', () => {
             />
           )
 
-          userEvent.type(
+          await user.type(
             screen.getByRole('textbox', {
               name: /onetimecode input field 1/i,
             }),
             '7568'
           )
 
-          userEvent.type(
+          await user.type(
             screen.getByRole('textbox', {
               name: /onetimecode input field 5/i,
             }),

--- a/src/components/OneTimeCodeInput/index.test.tsx
+++ b/src/components/OneTimeCodeInput/index.test.tsx
@@ -6,14 +6,6 @@ import { OneTimeCodeInput } from './'
 
 expect.extend(matchers)
 
-const fillOneTimeCode = async () => {
-  await screen.findByRole('textbox', { name: /onetimecode input field 1/i })
-  await screen.findByRole('textbox', { name: /onetimecode input field 2/i })
-  await screen.findByRole('textbox', { name: /onetimecode input field 3/i })
-  await screen.findByRole('textbox', { name: /onetimecode input field 4/i })
-  await screen.findByRole('textbox', { name: /onetimecode input field 5/i })
-}
-
 describe('OneTimeCodeInput', () => {
   describe('when the length is equal to 6', () => {
     it('renders a component with 6 inputs', () => {
@@ -80,8 +72,6 @@ describe('OneTimeCodeInput', () => {
         '75689'
       )
 
-      await fillOneTimeCode()
-
       expect(
         screen.getByRole('textbox', { name: /onetimecode input field 1/i })
       ).toHaveDisplayValue(/7/i)
@@ -117,8 +107,6 @@ describe('OneTimeCodeInput', () => {
         }),
         { target: { value: '75689' } }
       )
-
-      await fillOneTimeCode()
 
       expect(
         screen.getByRole('textbox', { name: /onetimecode input field 1/i })
@@ -192,8 +180,6 @@ describe('OneTimeCodeInput', () => {
           '75689'
         )
 
-        await fillOneTimeCode()
-
         userEvent.type(
           screen.getByRole('textbox', {
             name: /onetimecode input field 4/i,
@@ -228,8 +214,6 @@ describe('OneTimeCodeInput', () => {
             '75689'
           )
 
-          await fillOneTimeCode()
-
           userEvent.type(
             screen.getByRole('textbox', {
               name: /onetimecode input field 5/i,
@@ -237,7 +221,7 @@ describe('OneTimeCodeInput', () => {
             '{backspace}'
           )
 
-          waitFor(() => {
+          await waitFor(() => {
             expect(
               screen.getByRole('textbox', {
                 name: /onetimecode input field 5/i,
@@ -246,9 +230,9 @@ describe('OneTimeCodeInput', () => {
 
             expect(
               screen.getByRole('textbox', {
-                name: /onetimecode input field 4/i,
+                name: /onetimecode input field 5/i,
               })
-            ).toHaveDisplayValue('')
+            ).toHaveFocus()
           })
         })
       })
@@ -271,8 +255,6 @@ describe('OneTimeCodeInput', () => {
             '7568'
           )
 
-          await fillOneTimeCode()
-
           userEvent.type(
             screen.getByRole('textbox', {
               name: /onetimecode input field 5/i,
@@ -280,7 +262,7 @@ describe('OneTimeCodeInput', () => {
             '{backspace}'
           )
 
-          waitFor(() => {
+          await waitFor(() => {
             expect(
               screen.getByRole('textbox', {
                 name: /onetimecode input field 4/i,

--- a/src/components/Panel/index.test.tsx
+++ b/src/components/Panel/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Panel, PanelContent, PanelText, PanelBody } from '.'
 
 describe('Panel', () => {

--- a/src/components/PhoneInput/index.test.tsx
+++ b/src/components/PhoneInput/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { PhoneInput } from '.'
 import { color } from '../../theme'

--- a/src/components/Pill/index.test.tsx
+++ b/src/components/Pill/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { matchers } from '@emotion/jest'
 import { Pill, PillVariant } from '.'
 import { color } from '../../theme'

--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, render, fireEvent } from '@testing-library/react'
+import { screen, render, fireEvent } from '../../../test/test.utils'
 import { Select } from '.'
 import * as useDeviceInfo from '../../hooks/useDeviceInfo'
 

--- a/src/components/SpeechBubble/index.test.tsx
+++ b/src/components/SpeechBubble/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { SpeechBubble } from './'
 
 describe('SpeechBubble', () => {

--- a/src/components/Spinner/index.test.tsx
+++ b/src/components/Spinner/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Spinner } from '.'
 
 describe('Spinner', () => {

--- a/src/components/StarRating/index.test.tsx
+++ b/src/components/StarRating/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { StarRating } from '.'
 
 describe('StarRating', () => {

--- a/src/components/Tabs/index.test.tsx
+++ b/src/components/Tabs/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '.'
 
 const Content = () => (

--- a/src/components/TimeInput/index.test.tsx
+++ b/src/components/TimeInput/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent } from '../../../test/test.utils'
 import { TimeInput } from '.'
 
 describe('TimeInput', () => {

--- a/src/components/Toast/index.test.tsx
+++ b/src/components/Toast/index.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import { screen, render } from '@testing-library/react'
+import { screen, render } from '../../../test/test.utils'
 import { ToastProvider, ToastConsumer, Toast } from './'
-import userEvent from '@testing-library/user-event'
 
 describe('Toast', () => {
   it('shows button and renders toasts on button-click', async () => {
-    render(
+    const { user } = render(
       <ToastProvider>
         <ToastConsumer>
           {({ notify }) => (
@@ -18,13 +17,13 @@ describe('Toast', () => {
     )
 
     expect(await screen.findByText(/show toast/i)).toBeInTheDocument()
-    userEvent.click(await screen.findByText(/show toast/i))
-    userEvent.click(await screen.findByText(/show toast/i))
+    await user.click(await screen.findByText(/show toast/i))
+    await user.click(await screen.findByText(/show toast/i))
     expect(await screen.findAllByText(/notification/i)).toHaveLength(2)
   })
 
   it('hides toast', async () => {
-    render(
+    const { user } = render(
       <ToastProvider>
         <ToastConsumer>
           {({ notify }) => (
@@ -44,9 +43,9 @@ describe('Toast', () => {
         </ToastConsumer>
       </ToastProvider>
     )
-    userEvent.click(await screen.findByText(/show toast/i))
+    await user.click(await screen.findByText(/show toast/i))
     expect(await screen.findByText(/payment failed/i)).toBeInTheDocument()
-    userEvent.click(await screen.findByText(/discard/i))
+    await user.click(await screen.findByText(/discard/i))
     expect(screen.queryByText(/payment failed/i)).toBeNull()
   })
 })

--- a/src/components/Toggle/index.test.tsx
+++ b/src/components/Toggle/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render } from '../../../test/test.utils'
 import { Toggle } from '.'
 
 describe('Toggle', () => {

--- a/src/components/Tooltip/index.test.tsx
+++ b/src/components/Tooltip/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { Tooltip } from '.'
 
 describe('Tooltip', () => {

--- a/src/components/VisuallyHidden/index.test.tsx
+++ b/src/components/VisuallyHidden/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../../test/test.utils'
 import { VisuallyHidden } from '.'
 
 describe('VisuallyHidden', () => {

--- a/src/icons/index.test.tsx
+++ b/src/icons/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render } from '../../test/test.utils'
 import { Download } from './Download'
 
 describe('Icon', () => {

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react'
+
+export const customRender = (ui, options) => ({
+  ...render(ui, {
+    ...options,
+  }),
+})
+
+export * from '@testing-library/react'
+
+export { customRender as render }

--- a/test/test.utils.js
+++ b/test/test.utils.js
@@ -1,6 +1,10 @@
 import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 export const customRender = (ui, options) => ({
+  user: userEvent.setup({
+    delay: null,
+  }),
   ...render(ui, {
     ...options,
   }),
@@ -8,4 +12,4 @@ export const customRender = (ui, options) => ({
 
 export * from '@testing-library/react'
 
-export { customRender as render }
+export { customRender as render, userEvent }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4023,12 +4023,10 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "*"
 
-"@testing-library/user-event@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.0.4.tgz#5b430a9c27f25078bff4471661b755115d0db9d4"
+  integrity sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
# Description

**UserEvent v14** introduces some [breaking changes](
https://github.com/testing-library/user-event/releases/tag/v14.0.0).

See the commits for the necessary changes:
- All APIs now return a promise, so they need to be awaited;
- We now invoke the APIs on a setup user instead of the `userEvent` lib (a custom renderer is introduced to make this easier);

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn test`

## To be notified

@TicketSwap/frontend 

## Links
https://github.com/testing-library/user-event/releases/tag/v14.0.0