### PR TITLE
fix(Toast): change background and text color of toast for more contrast

### DIFF
--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -47,7 +47,7 @@ export interface ToastBlockProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const ToastContainer = styled.div<ToastBlockProps>`
   border-radius: ${radius.lg};
-  background-color: ${color.background};
+  background-color: ${color.invertedBackground};
   box-shadow: ${shadow.strong};
   padding: ${space[16]};
 
@@ -59,6 +59,9 @@ const ToastContainer = styled.div<ToastBlockProps>`
       grid-template-columns: auto 1fr;
       align-items: ${hasMultipleLines ? 'start' : 'center'};
     `}
+`
+const ToastText = styled.span`
+  color: ${color.invertedForeground};
 `
 
 interface ItemContainerStyles {
@@ -237,7 +240,7 @@ function Item({
         ref={ref}
       >
         <LeftAdornmentContainer>{leftAdornment}</LeftAdornmentContainer>
-        {children}
+        <ToastText>{children}</ToastText>
       </ToastContainer>
     </ItemContainer>
   )


### PR DESCRIPTION
# Description
Change background and text color of toast for more contrast, Mark suggested to have the toast in `invertedBackground` and text in `invertedForeground`. When the toast contains a button it looks a bit weird but this will be fixed later on. 

## Changes

- [x] Updated the background and text color of toast

## How to test

- Checkout this branch
- `$ yarn storybook`
- Search Toast 
- Make sure toast are black with white text 

## Screenshots
<img width="506" alt="Screenshot 2022-04-26 at 15 05 17" src="https://user-images.githubusercontent.com/34305012/165306359-682105c1-feb6-4d99-b0fb-fc325e1a9549.png">

## To be notified
@Marruk 

## Links
Fix issue [#1367](https://github.com/TicketSwap/solar/issues/1367)
