### PR TITLE
fix(OnboardingDialog): use the correct overlay

### DIFF
--- a/src/components/OnboardingDialog/index.tsx
+++ b/src/components/OnboardingDialog/index.tsx
@@ -79,13 +79,17 @@ const Backdrop = styled.div<BackdropProps>`
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: ${color.overlay};
+  background-color: #ffffff99;
   opacity: ${props =>
     props.state === TransitionState.ENTERING ||
     props.state === TransitionState.ENTERED
       ? 1
       : 0};
   transition: opacity ${transition};
+
+  [data-theme='dark'] & {
+    background-color: #1a212999;
+  }
 `
 
 const OnboardingWrapper: React.FC<OnboardingWrapperProps> = ({


### PR DESCRIPTION
# Description

The overlay was not correct on light mode, because it's always a dark
color. This is not how the onboarding dialog is supposed to use, so
this commit will use a light overlay on light mode and a dark overlay
on dark mode.

## Screenshots

Old
![Screenshot 2022-05-02 at 15 18 51](https://user-images.githubusercontent.com/14276144/166240221-3df6916a-f82c-4d60-b6e2-6c78455eafd4.png)


New
![Screenshot 2022-05-02 at 15 14 52](https://user-images.githubusercontent.com/14276144/166240183-f334f103-8978-42d4-b063-0d4534d526fe.png)

