### PR TITLE
fix(Toggle): Use dark foreground for loading state

### DIFF
--- a/src/components/Toggle/Switch.tsx
+++ b/src/components/Toggle/Switch.tsx
@@ -110,7 +110,11 @@ export const Switch: React.FC<SwitchProps> = ({
     <Button isOn={Boolean(on)} onClick={onClick} {...props}>
       {loading || adornment ? (
         <Adornment isOn={on}>
-          {loading ? <StyledSpinner size={16} /> : adornment ? adornment : null}
+          {loading ? (
+            <StyledSpinner color={color.darkForeground} size={16} />
+          ) : adornment ? (
+            adornment
+          ) : null}
         </Adornment>
       ) : null}
     </Button>


### PR DESCRIPTION
# Description

This PR makes sure that we use the correct color for the spinner in the loading state of the toggle.

## How to test

- Check the loading story of the Toggle in Storybook and verify it's working as expected

## Screenshots

Old
![Screenshot 2022-05-02 at 15 40 09](https://user-images.githubusercontent.com/14276144/166243943-a767ab35-fa9f-4f78-a6f3-477c40ca922f.png)

New
![Screenshot 2022-05-02 at 15 39 58](https://user-images.githubusercontent.com/14276144/166243930-335c51dd-e906-4a71-bc51-b0a7b99b5dbb.png)

