### PR TITLE
fix(logo): fix the svg and its spacing beneath it

### DIFF
--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -43,7 +43,7 @@ export const Logo = ({
 }: LogoProps) => (
   <SvgWrapper {...props}>
     <InlineSvg
-      viewBox="0 0 244 40"
+      viewBox="0 0 244 35"
       fillRule="evenodd"
       clipRule="evenodd"
       strokeLinejoin="round"


### PR DESCRIPTION
# Description

Fix some spacing in the svg that was causing it not to center properly

## How to test

- Checkout this branch
- `yarn storybook`
- Go to: `/?path=/story/components-content-logo--horizontal`
- Check with the inspector if it's better (compare it with the production build on github for example)

## Screenshots

Old:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/12168698/170030559-4c63ec31-9dbc-4022-b504-1f91b0e8b378.png">


New:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/12168698/170030450-ff1406ca-96ff-4787-aa03-73c13e7913ec.png">


## To be notified

@TicketSwap/frontend 
