### PR TITLE
Make it possible to focus OneTimeCodeInput on mount

### DIFF
--- a/src/components/OneTimeCodeInput/index.stories.tsx
+++ b/src/components/OneTimeCodeInput/index.stories.tsx
@@ -69,6 +69,37 @@ export const ShortCode = () => {
   )
 }
 
+export const WithFocusOnMount = () => {
+  return (
+    <Dialog on>
+      {({ getWindowProps }) => (
+        <>
+          <DialogWindow {...getWindowProps()}>
+            <DialogHeader>One Time Code Input</DialogHeader>
+            <DialogBody>
+              <OneTimeCodeInput
+                focusOnMount={true}
+                length={4}
+                id="otc-input"
+                label="Verificationcode"
+                helpText="Enter your 6 digit code here"
+                ariaLabel="One Time Code Input Field:"
+                validate={true}
+                onChange={value => console.log(value)}
+              />
+            </DialogBody>
+            <DialogFooter>
+              <Button onClick={() => console.log('submitted')} fullWidth>
+                Submit
+              </Button>
+            </DialogFooter>
+          </DialogWindow>
+        </>
+      )}
+    </Dialog>
+  )
+}
+
 export const LongCode = () => {
   return (
     <Dialog on>

--- a/src/components/OneTimeCodeInput/index.test.tsx
+++ b/src/components/OneTimeCodeInput/index.test.tsx
@@ -268,6 +268,44 @@ describe('OneTimeCodeInput', () => {
           })
         })
       })
+
+      describe('when focusOnMount is being', () => {
+        it('auto focus the first input when focusOnMount is true', async () => {
+          render(
+            <OneTimeCodeInput
+              id="OneTimeCodeInput"
+              length={5}
+              label="Verificationcode"
+              ariaLabel="OneTimeCode Input Field"
+              focusOnMount={true}
+            />
+          )
+
+          expect(
+            screen.getByRole('textbox', {
+              name: /onetimecode input field 1/i,
+            })
+          ).toHaveFocus()
+        })
+
+        it('does not focus the first input when focusOnMount is false', async () => {
+          render(
+            <OneTimeCodeInput
+              id="OneTimeCodeInput"
+              length={5}
+              label="Verificationcode"
+              ariaLabel="OneTimeCode Input Field"
+              focusOnMount={false}
+            />
+          )
+
+          expect(
+            screen.getByRole('textbox', {
+              name: /onetimecode input field 1/i,
+            })
+          ).not.toHaveFocus()
+        })
+      })
     })
   })
 })

--- a/src/components/OneTimeCodeInput/index.tsx
+++ b/src/components/OneTimeCodeInput/index.tsx
@@ -47,7 +47,9 @@ export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
   helpText,
   onChange = () => {},
 }) => {
-  const [inputValues, setInputValues] = useState(new Array(length).fill(''))
+  const [inputValues, setInputValues] = useState(
+    new Array(length === 0 ? 1 : length).fill('')
+  )
   const containerRef = useRef<HTMLInputElement>(null)
 
   const handleChange = (

--- a/src/components/OneTimeCodeInput/index.tsx
+++ b/src/components/OneTimeCodeInput/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from '@emotion/styled'
 import { fieldStyles, Help, LabelText } from '../Input'
 import { space } from '../../theme'
@@ -17,6 +17,7 @@ interface OneTimeCodeInputProps {
   ariaLabel: string
   label: string
   disabled?: boolean
+  focusOnMount?: boolean
   helpText?: string
   labelProps?: object
   validate?: boolean
@@ -38,6 +39,7 @@ const Input = styled.input`
 `
 
 export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
+  focusOnMount = false,
   length = 5,
   id,
   hideLabel,
@@ -51,6 +53,12 @@ export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
     new Array(length === 0 ? 1 : length).fill('')
   )
   const containerRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (focusOnMount && containerRef.current) {
+      containerRef.current.querySelectorAll('input')[0].focus()
+    }
+  }, [focusOnMount])
 
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement>,


### PR DESCRIPTION
# Description

Currently, it's not possible to focus the first input of the OneTimeCodeInput on mounting. This PR will make that possible.

## How to test

- Checkout
- Open Storybook
- Go to the `WithFocusOnMount` story of `OneTimeCodeInput` component
- Verify it will auto focus the first input on mounting
