### PR TITLE
Add z-index to Toast component

### DIFF
--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled'
 import { Text } from '../Text'
 import { CheckmarkRounded } from '../../icons'
 import { color, space } from '../../theme'
+import { Dialog, DialogBody, DialogHeader, DialogWindow } from '../Dialog'
 
 const ToastContent = styled.div`
   display: flex;
@@ -178,11 +179,42 @@ function PersistentWithAdornment() {
   )
 }
 
+const WithDialog = () => {
+  const { notify } = useToast()
+
+  return (
+    <Dialog>
+      {({ hide, getToggleProps, getWindowProps }) => (
+        <>
+          <Button {...getToggleProps()}>Show dialog</Button>
+          <DialogWindow {...getWindowProps()}>
+            <DialogHeader>Dialog Title</DialogHeader>
+            <DialogBody>
+              <Button
+                onClick={() =>
+                  notify(() => (
+                    <Toast persist>
+                      <Text>Notification</Text>
+                    </Toast>
+                  ))
+                }
+              >
+                Show toast
+              </Button>
+            </DialogBody>
+          </DialogWindow>
+        </>
+      )}
+    </Dialog>
+  )
+}
+
 export const BasicToast = () => <Basic />
 export const WithAdornmentToast = () => <WithAdornment />
 export const WithInputToast = () => <WithInput />
 export const PersistentToast = () => <Persistent />
 export const PersistentWithAdornmentToast = () => <PersistentWithAdornment />
+export const withDialogToast = () => <WithDialog />
 
 BasicToast.storyName = 'Basic'
 WithAdornmentToast.storyName = 'With Adornment'

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -15,6 +15,7 @@ const ItemListContainer = styled.ul`
   max-width: 100%;
   flex-direction: column-reverse;
   pointer-events: none;
+  z-index: 2147483646; /* largest accepted z-index value as integer minus 1 */
 
   @media ${device.tablet} {
     left: ${space[16]};


### PR DESCRIPTION
# Description

Currently, the toast component is showing behind the dialog overlay. We want to make sure that a toast is always visible, so by adding a z-index we can make sure it overlaps the dialog overlay.

## How to test

- Checkout this branch
- Open Storybook
- Go to the With Dialog Toast story of the toast component
- Verify the toast is being shown above the dialog overlay

## Screenshots

![Screenshot 2022-06-20 at 12 07 48](https://user-images.githubusercontent.com/14276144/174579162-d7cf8e61-a083-4710-84b5-616831b1a77e.png)


## To be notified

@Marruk 
