### PR TITLE
Make it possible to use string values for Typescript enums

### DIFF
--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -33,7 +33,7 @@ export enum AlertVariant {
 export interface AlertProps {
   title?: string
   action?: AlertAction
-  variant?: AlertVariant
+  variant?: keyof typeof AlertVariant
   children: ReactNode
 }
 
@@ -155,8 +155,6 @@ const Alert: React.FC<AlertProps> = ({
         )}
       </Adornment>
       <Main>
-        {/* Will be fixed in version 11 of emotion: https://github.com/emotion-js/emotion/pull/1874 */}
-        {/* @ts-ignore */}
         {title && <Title as="h4">{title}</Title>}
         <Message>{children}</Message>
         {action && (

--- a/src/components/BaseButton/index.tsx
+++ b/src/components/BaseButton/index.tsx
@@ -18,9 +18,9 @@ export enum BaseButtonSize {
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   leftAdornment?: ReactNode
-  variant?: ButtonVariant
+  variant?: keyof typeof ButtonVariant
   disabled?: boolean
-  size?: BaseButtonSize
+  size?: keyof typeof BaseButtonSize
 }
 
 const StyledButton = styled.button<ButtonProps>`

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -33,9 +33,9 @@ export enum ButtonSize {
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariant
+  variant?: keyof typeof ButtonVariant
   leftAdornment?: ReactNode
-  size?: ButtonSize
+  size?: keyof typeof ButtonSize
   fullWidth?: boolean
   loading?: boolean
   active?: boolean
@@ -278,7 +278,7 @@ const StyledButton = styled.button<StyledButtonProps>`
 `
 
 interface LeftAdornmentProps {
-  size: ButtonSize
+  size: keyof typeof ButtonSize
   isSquare: boolean
 }
 

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -32,8 +32,8 @@ export interface CardPropTypes {
   leftAdornment?: React.ReactNode
   rightAdornment?: React.ReactNode
   topLeftAdornment?: React.ReactNode
-  verticalAlign?: CardVerticalAlign
-  size?: CardSize
+  verticalAlign?: keyof typeof CardVerticalAlign
+  size?: keyof typeof CardSize
   footer?: React.ReactNode
 }
 

--- a/src/components/ContentDialog/index.tsx
+++ b/src/components/ContentDialog/index.tsx
@@ -40,7 +40,7 @@ const duration = 200
 
 interface StyledTransitionProps {
   onScroll?: Function
-  state: TransitionState
+  state: keyof typeof TransitionState
 }
 
 const StyledDialogOverlay = styled<React.FC<DialogOverlayProps>>(
@@ -55,7 +55,10 @@ const StyledDialogOverlay = styled<React.FC<DialogOverlayProps>>(
   background-color: ${color.overlay};
   z-index: 2147483646; /* largest accepted z-index value as integer minus 1 */
   opacity: ${props =>
-    props.state === 'entering' || props.state === 'entered' ? 1 : 0};
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED
+      ? 1
+      : 0};
   transition: opacity ${duration}ms ${easing.easeOutCubic};
   backdrop-filter: blur(16px);
 `
@@ -73,7 +76,8 @@ const StyledDialogContent = styled<React.FC<DialogContentProps>>(
   background: ${color.background};
   outline: none;
   transform: ${props =>
-    props.state === 'entering' || props.state === 'entered'
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED
       ? 'translate3d(0,0,0)'
       : 'translate3d(0,1rem,0)'};
   transition: transform ${duration}ms ${easing.easeOutCubic};
@@ -86,9 +90,9 @@ const StyledDialogContent = styled<React.FC<DialogContentProps>>(
     min-height: auto;
     transform: ${props => {
       switch (props.state) {
-        case 'exited':
+        case 'EXITED':
           return 'translate3d(0,-1rem,0)'
-        case 'exiting':
+        case 'EXITING':
           return 'translate3d(0,1rem,0)'
         default:
           return 'translate3d(0,0,0)'

--- a/src/components/ContentTransition/index.tsx
+++ b/src/components/ContentTransition/index.tsx
@@ -10,7 +10,7 @@ const Container = styled.div`
 `
 
 interface SlideContainerProps {
-  state: TransitionState
+  state: keyof typeof TransitionState
   from: string
   to: string
   initial: boolean
@@ -19,14 +19,18 @@ interface SlideContainerProps {
 const SlideContainer = styled.div<SlideContainerProps>`
   width: 100%;
   top: 0;
-  position: ${props => (props.state === 'exiting' ? 'absolute' : 'relative')};
+  position: ${props =>
+    props.state === TransitionState.EXITING ? 'absolute' : 'relative'};
   opacity: ${props =>
-    props.state === 'entering' || props.state === 'entered' ? 1 : 0};
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED
+      ? 1
+      : 0};
   transform: ${props => {
     switch (props.state) {
-      case 'exited':
+      case TransitionState.EXITED:
         return `translate3d(${props.initial ? 0 : props.from},0,0)`
-      case 'exiting':
+      case TransitionState.EXITING:
         return `translate3d(${props.to},0,0)`
       default:
         return 'translate3d(0,0,0)'
@@ -36,8 +40,9 @@ const SlideContainer = styled.div<SlideContainerProps>`
   transition-timing-function: ${easing.easeOutCubic};
   transition-property: opacity, transform;
   /* Make sure the exiting slide doesn’t reach outside the dialog */
-  overflow: ${props => (props.state === 'exiting' ? 'hidden' : 'visible')};
-  bottom: ${props => (props.state === 'exiting' ? 0 : 'auto')};
+  overflow: ${props =>
+    props.state === TransitionState.EXITING ? 'hidden' : 'visible'};
+  bottom: ${props => (props.state === TransitionState.EXITING ? 0 : 'auto')};
 `
 
 export interface SlideProps {

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -63,7 +63,7 @@ export interface DialogProps extends UseDialogProps {
 }
 
 interface DialogOverlayStyles {
-  state: TransitionState
+  state: keyof typeof TransitionState
 }
 
 const DialogOverlay = styled.div<DialogOverlayStyles>`
@@ -78,7 +78,7 @@ const DialogOverlay = styled.div<DialogOverlayStyles>`
   justify-content: center;
   align-items: flex-end;
   opacity: ${props =>
-    props.state === 'entering' || props.state === 'entered' ? 1 : 0};
+    props.state === 'ENTERING' || props.state === 'ENTERED' ? 1 : 0};
   transition: opacity ${duration}ms ${easing.easeOutCubic};
   backdrop-filter: blur(16px);
 
@@ -94,7 +94,7 @@ const DialogOverlay = styled.div<DialogOverlayStyles>`
 `
 
 interface ContentStyles {
-  state?: TransitionState
+  state?: keyof typeof TransitionState
 }
 
 const Content = styled.div<ContentStyles>`
@@ -104,7 +104,8 @@ const Content = styled.div<ContentStyles>`
   border-radius: ${radius.lg} ${radius.lg} 0 0;
   overflow: hidden;
   transform: ${props =>
-    props.state === 'entering' || props.state === 'entered'
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED
       ? 'translate3d(0,0,0)'
       : 'translate3d(0,1rem,0)'};
   transition: transform ${duration}ms ${easing.easeOutCubic};
@@ -115,9 +116,9 @@ const Content = styled.div<ContentStyles>`
     overflow: unset;
     transform: ${props => {
       switch (props.state) {
-        case 'exited':
+        case 'EXITED':
           return 'translate3d(0,-1rem,0)'
-        case 'exiting':
+        case 'EXITING':
           return 'translate3d(0,1rem,0)'
         default:
           return 'translate3d(0,0,0)'

--- a/src/components/Logo/Path.tsx
+++ b/src/components/Logo/Path.tsx
@@ -6,7 +6,7 @@ export enum LogoVariant {
 }
 
 export interface PathProps {
-  variant: LogoVariant
+  variant: keyof typeof LogoVariant
 }
 
 export const Path = ({ variant }: PathProps) => (

--- a/src/components/Logo/Path.tsx
+++ b/src/components/Logo/Path.tsx
@@ -1,9 +1,5 @@
 import React from 'react'
-
-export enum LogoVariant {
-  default = 'default',
-  lgbt = 'lgbt',
-}
+import { LogoVariant } from '.'
 
 export interface PathProps {
   variant: keyof typeof LogoVariant

--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -34,7 +34,7 @@ export enum LogoVariant {
 }
 
 export interface LogoProps {
-  variant?: LogoVariant
+  variant?: keyof typeof LogoVariant
 }
 
 export const Logo = ({

--- a/src/components/MenuButton/index.tsx
+++ b/src/components/MenuButton/index.tsx
@@ -36,7 +36,7 @@ export const Menu = ({ children, ...props }: MenuProps) => {
 }
 
 export interface MenuListProps extends ReachMenuListProps {
-  state: TransitionState
+  state: keyof typeof TransitionState
 }
 
 const StyledMenuList = styled<React.FC<MenuListProps>>(ReachMenuList)`
@@ -67,11 +67,14 @@ const StyledMenuList = styled<React.FC<MenuListProps>>(ReachMenuList)`
   }
 
   opacity: ${props =>
-    props.state === 'entering' || props.state === 'entered' ? 1 : 0};
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED
+      ? 1
+      : 0};
   transform: ${props =>
-    props.state === 'entering' ||
-    props.state === 'entered' ||
-    props.state === 'exiting'
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED ||
+    props.state === TransitionState.EXITING
       ? 'translateY(0)'
       : `translateY(1rem)`};
   transition: opacity ${DURATION}ms ${easing.easeInOutCubic},

--- a/src/components/OnboardingDialog/index.tsx
+++ b/src/components/OnboardingDialog/index.tsx
@@ -130,8 +130,7 @@ export interface useOnboardingProps {
 }
 
 function useOnboarding(config: useOnboardingProps = {}) {
-  const { defaultOn = true, defaultTransitionState = TransitionState.EXITED } =
-    config
+  const { defaultOn = true } = config
 
   const [show, setShow] = useState(defaultOn)
   const [active, setActive] = useState(defaultOn)
@@ -139,7 +138,6 @@ function useOnboarding(config: useOnboardingProps = {}) {
     in: show,
     timeout: duration,
     onExited: () => setActive(false),
-    defaultTransitionState,
   })
 
   return {

--- a/src/components/OnboardingDialog/index.tsx
+++ b/src/components/OnboardingDialog/index.tsx
@@ -46,7 +46,7 @@ const DialogWrapper = styled.div<DialogWrapperProps>`
 
 export interface OnboardingDialogProps {
   show: boolean
-  state: TransitionState
+  state: keyof typeof TransitionState
   active: boolean
   children: ReactNode
 }
@@ -79,7 +79,7 @@ const Container = styled.div`
 `
 
 interface BackdropProps {
-  state: TransitionState
+  state: keyof typeof TransitionState
 }
 
 const Backdrop = styled.div<BackdropProps>`
@@ -126,7 +126,7 @@ const Onboarding: React.FC<OnboardingProps> = ({
 
 export interface useOnboardingProps {
   defaultOn?: boolean
-  defaultTransitionState?: TransitionState
+  defaultTransitionState?: keyof typeof TransitionState
 }
 
 function useOnboarding(config: useOnboardingProps = {}) {

--- a/src/components/Pill/index.tsx
+++ b/src/components/Pill/index.tsx
@@ -66,7 +66,7 @@ export enum PillVariant {
 }
 
 export interface PillProps {
-  variant?: PillVariant
+  variant?: keyof typeof PillVariant
   leftAdornment?: ReactNode
   children: ReactNode
 }

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -48,7 +48,7 @@ type SelectItem = {
   displayName?: string
   leftAdornment?: ReactNode
   rightAdornment?: ReactNode
-  type?: SelectItemType
+  type?: keyof typeof SelectItemType
   onClick?: Function
 }
 

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -67,7 +67,7 @@ const ToastText = styled.span`
 `
 
 interface ItemContainerStyles {
-  state: TransitionState
+  state: keyof typeof TransitionState
 }
 
 const ItemContainer = styled.li<ItemContainerStyles>`
@@ -78,7 +78,8 @@ const ItemContainer = styled.li<ItemContainerStyles>`
   padding-inline: ${space[16]};
   opacity: 0;
   transform: ${props =>
-    props.state === 'entering' || props.state === 'entered'
+    props.state === TransitionState.ENTERING ||
+    props.state === TransitionState.ENTERED
       ? 'translate3d(0,0,0)'
       : 'translate3d(0,1rem,0)'};
   transition-duration: ${duration}ms;
@@ -91,19 +92,28 @@ const ItemContainer = styled.li<ItemContainerStyles>`
 
   &:nth-last-of-type(3) {
     opacity: ${props =>
-      props.state === 'entering' || props.state === 'entered' ? 0.6 : 0};
+      props.state === TransitionState.ENTERING ||
+      props.state === TransitionState.ENTERED
+        ? 0.6
+        : 0};
     transform: translate3d(0, -1.2rem, 0) scale(0.96);
   }
 
   &:nth-last-of-type(2) {
     opacity: ${props =>
-      props.state === 'entering' || props.state === 'entered' ? 0.8 : 0};
+      props.state === TransitionState.ENTERING ||
+      props.state === TransitionState.ENTERED
+        ? 0.8
+        : 0};
     transform: translate3d(0, -0.6rem, 0) scale(0.98);
   }
 
   &:last-of-type {
     opacity: ${props =>
-      props.state === 'entering' || props.state === 'entered' ? 1 : 0};
+      props.state === TransitionState.ENTERING ||
+      props.state === TransitionState.ENTERED
+        ? 1
+        : 0};
     position: relative;
   }
 `

--- a/src/hooks/useTransition/index.ts
+++ b/src/hooks/useTransition/index.ts
@@ -2,27 +2,29 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect'
 import { usePrevious } from '../usePrevious'
 
-export const EXITED = 'exited'
-export const ENTERING = 'entering'
-export const ENTERED = 'entered'
-export const EXITING = 'exiting'
+export const EXITED = 'EXITED'
+export const ENTERING = 'ENTERING'
+export const ENTERED = 'ENTERED'
+export const EXITING = 'EXITING'
 
 export enum TransitionState {
-  EXITED = 'exited',
-  ENTERING = 'entering',
-  ENTERED = 'entered',
-  EXITING = 'exiting',
+  EXITED = 'EXITED',
+  ENTERING = 'ENTERING',
+  ENTERED = 'ENTERED',
+  EXITING = 'EXITING',
 }
 
 interface useTransitionParameters {
   in: boolean
   timeout: number
-  defaultTransitionState?: TransitionState
+  defaultTransitionState?: keyof typeof TransitionState
   onExited?: Function
   onEntering?: Function
   onEntered?: Function
   onExiting?: Function
 }
+
+type DefaultTransitionState = keyof typeof TransitionState
 
 export const useTransition = ({
   in: on,
@@ -32,7 +34,7 @@ export const useTransition = ({
   onEntering = () => {},
   onEntered = () => {},
   onExiting = () => {},
-}: useTransitionParameters): [TransitionState, boolean, boolean] => {
+}: useTransitionParameters): [DefaultTransitionState, boolean, boolean] => {
   const [state, setState] = useState(defaultTransitionState)
   const [mounted, setMounted] = useState(false)
 


### PR DESCRIPTION
# Description

This PR makes it possible to use string values for Typescript enums. Currently, if you would use Solar you need to use `ButtonSize.large` when you want to declare the size of the `Button` component. This PR makes it possible to use the value of the enum as well, so like this: `<Button size="large">Hello world</Button>`.

The enums of the components are working with a lowercase value, and I think that makes sense for enums that are being used for props. The enum `TransitionState` is more for config of the transitions (and `useTransition`) and I think it makes more sense to use uppercase values for that. This means that we have a breaking change in that.

Let me know what you think!

## Changes

- [x] Make it possible to use string values for enums
- [x] Removed unneeded type in Logo/Path
- [x] Removed unneeded default transition in OnboardingDialog

## How to test

- Checkout this branch
- `$ yarn dev`
- Verify the related components (Buttons, Alerts, Dialogs, etc.) are working as expected in Storybook