### PR TITLE
fix(Alert): fixed horizontal padding in Alert being on the wrong side

### DIFF
--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -88,11 +88,11 @@ const Adornment = styled.span`
 const Main = styled.div`
   flex-basis: 100%;
   padding-block: ${11 / 16}rem ${10 / 16}rem;
-  padding-inline: ${10 / 16}rem 0;
+  padding-inline: 0 ${10 / 16}rem;
 
   @media ${device.tablet} {
     padding-block: ${15 / 16}rem ${14 / 16}rem;
-    padding-inline: ${14 / 16}rem 0;
+    padding-inline: 0 ${14 / 16}rem;
   }
 `
 


### PR DESCRIPTION
# Description
The horizontal padding for the content in Alerts was switched around, having spacing on the left and not on the right as it should.

## Links
Fixes https://github.com/TicketSwap/solar/issues/1483
