### PR TITLE
Fix vertical alignment in the Card component

### DIFF
--- a/src/components/Card/index.stories.tsx
+++ b/src/components/Card/index.stories.tsx
@@ -113,26 +113,29 @@ export const WithTextAndSubtitle = () => (
       <Card
         title="Eurovision Song Contest - 1st Semi Final Jury Show"
         subtitle="I'm a subtitle"
-        text="Lorem ipsum dolor sit amet."
-        verticalAlign={CardVerticalAlign.top}
+        text="The card is aligned to the bottom."
+        leftAdornment={
+          <Avatar size={44} src="https://www.placecage.com/200/200" />
+        }
+        verticalAlign={CardVerticalAlign.bottom}
       />
     </a>
     <a href="/" style={{ minWidth: 0 }}>
       <Card
         title="Eurovision Song Contest - 1st Semi Final Family Show"
         subtitle="I'm a subtitle"
-        text="Lorem ipsum dolor sit amet."
+        text="The card is aligned to the center."
         leftAdornment={
           <Avatar size={44} src="https://www.placecage.com/200/200" />
         }
-        verticalAlign={CardVerticalAlign.top}
+        verticalAlign={CardVerticalAlign.center}
       />
     </a>
     <a href="/" style={{ minWidth: 0 }}>
       <Card
         title="Eurovision Song Contest - Grand Final Live Show"
         subtitle="I'm a subtitle"
-        text="Lorem ipsum dolor sit amet."
+        text="The card is aligned to the top."
         leftAdornment={
           <Avatar size={44} src="https://www.placecage.com/200/200" />
         }

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -338,7 +338,7 @@ const Card: React.FC<CardPropTypes> = ({
           <TopLeftAdornment>{topLeftAdornment}</TopLeftAdornment>
         )}
 
-        <Body hasImage={hasImage}>
+        <Body hasImage={hasImage} verticalAlign={verticalAlign}>
           {leftAdornment && <LeftAdornment>{leftAdornment}</LeftAdornment>}
 
           <TextContent hasImage={hasImage}>


### PR DESCRIPTION
# Description

This PR will make sure to respect the vertical alignment prop of the Card component, see first commit for the bugfix and see second commit for an example in Storybook.

## How to test

- Go to https://ticketswap.github.io/solar/?path=/story/components-surfaces-card--with-text-and-subtitle
- Verify the adornments are not vertical aligned to the top (although they have that prop set)

- Checkout this branch
- `$ yarn storybook`
- Go to the `With Text and Subtitle` story of the Card component
- Verify the adornments are vertical aligned to the right position

## Screenshots

![Screenshot 2022-06-24 at 20 18 39](https://user-images.githubusercontent.com/14276144/175625224-87ef792f-5cfb-42d1-be01-a72468c670b8.png)

