### PR TITLE
fix(Dialog): lower the z-index to show toasts

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -68,7 +68,7 @@ interface DialogOverlayStyles {
 
 const DialogOverlay = styled.div<DialogOverlayStyles>`
   position: fixed;
-  z-index: 2147483646; /* largest accepted z-index value as integer minus 1 */
+  z-index: 2147483645; /* largest accepted z-index value as integer minus 2 */
   left: 0;
   top: 0;
   right: 0;


### PR DESCRIPTION
# Description

We always want to show the toasts on top of the dialog. Because they
have the same z-index currently, it really depends on the html structure
which element is shown on top. By making sure the dialog overlay has
a lower z-index than the toast, the toast will always be shown on top
of the dialog.

## How to test
* Checkout
* `yarn`
* `yarn storybook`
* go to the `WithDialog` story of the Toast component