### PR TITLE
feat(OneTimeCodeInput): Add type="number"

### DIFF
--- a/src/components/OneTimeCodeInput/index.tsx
+++ b/src/components/OneTimeCodeInput/index.tsx
@@ -137,6 +137,7 @@ export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
             value={value}
             key={index}
             label={label}
+            pattern="\d*"
             validate={true}
             disabled={disabled}
             id={`${id}-${index + 1}`}


### PR DESCRIPTION
# Description

I was using this OneTimeCodeInput on my mobile phone and it worked not super nice, because everytime I had to switch back to my numeric keyboard after using one number.

This PR makes sure that the OneTimeCodeInput is always showing a numeric keyboard on mobile devices.

## How to test

- Checkout this branch
- `$ yarn storybook`
- Visit `localhost:9001` on your phone (I used an iPhone emulator)
- Go to the OneTimeCodeInput story
- Verify your keyboard doesn't switch after typing in a number

## Screenshots

Old
https://user-images.githubusercontent.com/14276144/176733275-79d21c81-6500-4f59-b5ef-407366a230f5.mov



New
https://user-images.githubusercontent.com/14276144/176732974-84068863-87f9-4b29-ae88-fc983de992c6.mov


