### PR TITLE
fix: Use action color for `a` and `button`

### DIFF
--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -255,7 +255,7 @@ export const globalStyles = css`
 
   a {
     text-decoration: none;
-    color: ${color.earth};
+    color: ${color.action};
   }
 
   button {
@@ -265,7 +265,7 @@ export const globalStyles = css`
     margin-inline: 0;
     border: none;
     font: inherit;
-    color: ${color.earth};
+    color: ${color.action};
     background-color: transparent;
     cursor: pointer;
     border-radius: ${radius.md};


### PR DESCRIPTION
# Description

See files changed. The `a` and `button` are representing actions, so they should use an action color, instead of the theme independent brand colors (such as earth).