### PR TITLE
fix:checking if selectedItem exists on Dropdown select input

### DIFF
--- a/src/utils/dates/index.test.ts
+++ b/src/utils/dates/index.test.ts
@@ -147,28 +147,70 @@ describe('dates', () => {
       ])
     })
 
-    it('returns only the months within a timeRange', () => {
-      const monthsOfTimeRange = getMonths('en-EN', {
-        start: new Date('02-12-2023'),
-        end: new Date('04-20-2023'),
+    describe('and it has a dateRange', () => {
+      describe('and this timeRange is on the same year', () => {
+        it('returns only the months within a timeRange', () => {
+          const monthsOfTimeRange = getMonths('en-EN', {
+            start: new Date('02-12-2023'),
+            end: new Date('04-20-2023'),
+          })
+          expect(monthsOfTimeRange).toHaveLength(3)
+          expect(monthsOfTimeRange).toEqual(
+            expect.arrayContaining([
+              {
+                name: 'February',
+                value: '1',
+              },
+              {
+                name: 'March',
+                value: '2',
+              },
+              {
+                name: 'April',
+                value: '3',
+              },
+            ])
+          )
+        })
       })
-      expect(monthsOfTimeRange).toHaveLength(3)
-      expect(monthsOfTimeRange).toEqual(
-        expect.arrayContaining([
-          {
-            name: 'February',
-            value: '1',
-          },
-          {
-            name: 'March',
-            value: '2',
-          },
-          {
-            name: 'April',
-            value: '3',
-          },
-        ])
-      )
+
+      describe('and this timeRange is on a different year', () => {
+        it('returns the months within the timeRange', () => {
+          const monthsOfTimeRange = getMonths('en-EN', {
+            start: new Date('11-12-2023'),
+            end: new Date('04-20-2024'),
+          })
+          expect(monthsOfTimeRange).toHaveLength(6)
+          expect(monthsOfTimeRange).toEqual(
+            expect.arrayContaining([
+              {
+                name: 'November',
+                value: '10',
+              },
+              {
+                name: 'December',
+                value: '11',
+              },
+              {
+                name: 'January',
+                value: '0',
+              },
+              {
+                name: 'February',
+                value: '1',
+              },
+              {
+                name: 'March',
+                value: '2',
+              },
+              {
+                name: 'April',
+                value: '3',
+              },
+            ])
+          )
+        })
+      })
     })
 
     describe('when provided with different "BCP 47" locale tags', () => {

--- a/src/utils/dates/index.ts
+++ b/src/utils/dates/index.ts
@@ -43,13 +43,31 @@ const getMonths = (locale: string, dateRange?: { start: Date; end: Date }) => {
   }
 
   if (dateRange) {
+    const startYear = dateRange.start.getFullYear()
+    const endYear = dateRange.end.getFullYear()
+
+    // check if the date range is on different years
+    if (endYear !== startYear) {
+      const monthsOfTheYearAfterStartMonth = months.filter(
+        month => Number(month.value) >= dateRange.start.getMonth()
+      )
+
+      const monthsOfTheYearBeforeEndMonth = months.filter(
+        month => Number(month.value) <= dateRange.end.getMonth()
+      )
+
+      return [
+        ...monthsOfTheYearAfterStartMonth,
+        ...monthsOfTheYearBeforeEndMonth,
+      ]
+    }
+
     return months.filter(
       month =>
         Number(month.value) >= dateRange.start.getMonth() &&
         Number(month.value) <= dateRange.end.getMonth()
     )
   }
-
   return months
 }
 
@@ -64,7 +82,6 @@ const generateYears = (startYear: number, endYear: number) => {
 
     startYear++
   }
-
   return years
 }
 


### PR DESCRIPTION
# Description
The bug is actually an edge case. The dateRange picker is opening the selects (year, months) but in the case of the `months` select, the value array is empty when dateRange is on different years. The util to get the month list was filtering the month between `startDate` and the `endDate`. So anything that will be superior to the `startDateMonth` (for ex. 6) but inferior to the `endDateMonth` (for ex. 1), which would return an empty array and therefore cause the error.  
 
https://ticketswap.atlassian.net/browse/TISSUES-799