### PR TITLE
Introduce `onBrand` and some other style adjustments

### DIFF
--- a/docs/Guidelines/Colors/data.ts
+++ b/docs/Guidelines/Colors/data.ts
@@ -73,6 +73,12 @@ export const semanticColors = [
         hex: '#00B6F0',
         foreground: color.lightForeground,
       },
+      {
+        label: 'On Brand',
+        variant: color.onBrand,
+        hex: '#FFFFFF',
+        foreground: color.onBrand,
+      },
     ],
   },
   {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -170,8 +170,9 @@ const StyledButton = styled.button<StyledButtonProps>`
     css`
       background-color: ${color.actionBackground};
       color: ${color.action};
+      background-image: unset;
 
-      [data-theme='dark'] & {
+      &:hover {
         background-image: unset;
       }
     `};

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -157,7 +157,7 @@ const TextContent = styled.div<StyledCardProps>`
   ${props =>
     props.hasImage &&
     css`
-      color: ${color.foregroundMuted};
+      color: ${color.lightForegroundMuted};
     `};
 `
 

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -60,6 +60,7 @@ export const globalStyles = css`
 
     // Brand
     --brand: var(--earth400);
+    --onBrand: var(--nova);
 
     // Foreground
     --foreground: var(--stardust900);
@@ -146,6 +147,7 @@ export const globalStyles = css`
   [data-theme='dark'] {
     // Brand
     --brand: var(--earth400);
+    --onBrand: var(--nova);
 
     // Foreground
     --foreground: var(--nova);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/react'
 
 export const color = {
   brand: 'var(--brand)',
+  onBrand: 'var(--onBrand)',
   foreground: 'var(--foreground)',
   foregroundMuted: 'var(--foregroundMuted)',
   foregroundSubtle: 'var(--foregroundSubtle)',


### PR DESCRIPTION
# Description

Together with Mark, I went over some things, and we decided to introduce an `onBrand` color so that it gets easier to have themes. Made a fix for the Card component, by changing the text to lightForegroundMuted if it's on an image (good reminder that texts on images should always use the independent `light` version). Also removed the background-image from the secondary variant button. Design is working on new buttons, where the background-image gets removed anyway, but at the moment it doesn't benefit the secondary button at all, and is only causing style issues, so we decided to remove it for the time being.

## How to test

- Checkout this branch
- `yarn storybook`
- Verify everything is working as expected
