### PR TITLE
Changed some usages of the palette colors to semantic variants

### DIFF
--- a/src/components/ContentTransition/index.stories.tsx
+++ b/src/components/ContentTransition/index.stories.tsx
@@ -52,7 +52,7 @@ const Login = (props: {
     </div>
     <div>
       Don’t have an account yet?{' '}
-      <button style={{ color: color.earth }} onClick={props.showSignupView}>
+      <button style={{ color: color.action }} onClick={props.showSignupView}>
         Sign up
       </button>
     </div>
@@ -91,7 +91,7 @@ const Signup = (props: {
     </div>
     <div>
       Already have an account{' '}
-      <button style={{ color: color.earth }} onClick={props.showLoginView}>
+      <button style={{ color: color.action }} onClick={props.showLoginView}>
         Log in
       </button>
     </div>

--- a/src/components/DatePicker/Day.tsx
+++ b/src/components/DatePicker/Day.tsx
@@ -42,10 +42,10 @@ const DayButton = styled.button<DayButtonProps>`
   ${({ selected }) =>
     selected &&
     css`
-      background-color: ${color.earth};
+      background-color: ${color.action};
 
       p {
-        color: ${color.lightForeground};
+        color: ${color.onAction};
       }
     `}
   ${({ disabled }) =>

--- a/src/components/Logo/index.stories.tsx
+++ b/src/components/Logo/index.stories.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import { color } from '../../theme'
 
 const StyledLogo = styled(Logo)`
-  color: ${color.earth};
+  color: ${color.brand};
 `
 
 export default {

--- a/src/components/Pill/index.tsx
+++ b/src/components/Pill/index.tsx
@@ -23,7 +23,7 @@ export const Container = styled.span<PillProps>`
     p.variant === 'danger'
       ? color.onFailure
       : p.variant === 'secondary'
-      ? color.earth
+      ? color.action
       : p.variant === 'success'
       ? color.onSuccess
       : p.variant === 'warning'

--- a/src/components/RadioGroup/Radio.tsx
+++ b/src/components/RadioGroup/Radio.tsx
@@ -27,8 +27,8 @@ const StyledInput = styled.input`
   transition: all ${transition};
 
   &:checked {
-    background-color: ${color.earth};
-    border-color: ${color.earth};
+    background-color: ${color.action};
+    border-color: ${color.action};
   }
 
   &:disabled {

--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -45,7 +45,7 @@ function WithAdornment() {
         notify(() => (
           <Toast
             persist
-            leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
+            leftAdornment={<CheckmarkRounded color={color.success} size={24} />}
           >
             <Text>Your preferences have been successfully updated</Text>
           </Toast>
@@ -134,7 +134,9 @@ function PersistentWithAdornment() {
           notify(remove => (
             <Toast
               persist
-              leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
+              leftAdornment={
+                <CheckmarkRounded color={color.success} size={24} />
+              }
             >
               <ToastContent>
                 <Text>Your preferences have been successfully updated</Text>
@@ -157,7 +159,9 @@ function PersistentWithAdornment() {
           notify(remove => (
             <Toast
               persist
-              leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
+              leftAdornment={
+                <CheckmarkRounded color={color.success} size={24} />
+              }
             >
               <ToastContent>
                 <Text>Saved!</Text>

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -225,8 +225,8 @@ export const globalStyles = css`
   }
 
   ::selection {
-    background-color: ${color.earth};
-    color: ${color.lightForeground};
+    background-color: ${color.brand};
+    color: ${color.onBrand};
   }
 
   *,


### PR DESCRIPTION
While testing the ADE theme I noticed that the "Day" element in the date picker was using the `earth` color (which made it unthemed). Figured I would fix that and check for other usages of the non-semantic colors, and change those to a semantic color as well.