### PR TITLE
Make improvements to various inputs

### DIFF
--- a/src/components/InputV2/InputWithLabel.tsx
+++ b/src/components/InputV2/InputWithLabel.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.span`
 
 export interface InputWithAriaLabel extends InputProps {
   id: string
-  instruction?: ReactElement | null
+  instruction?: ReactElement
   label?: string
 }
 
@@ -25,7 +25,7 @@ export type InputWithLabelProps = InputWithAriaLabel | InputWithRequiredLabel
 
 export const InputWithLabel = ({
   id,
-  instruction = null,
+  instruction,
   label,
   'aria-label': ariaLabel,
   ...props

--- a/src/components/MoneyInputV2/MoneyInput.tsx
+++ b/src/components/MoneyInputV2/MoneyInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import styled from '@emotion/styled'
 import { Input, InputProps } from '../InputV2'
 import { Select, SelectProps } from '../SelectV2'
@@ -8,13 +8,19 @@ export interface MoneyInputProps {
   legend?: string
   currencyProps: SelectProps
   amountProps: InputProps
+  instruction?: ReactNode
 }
 
 const Legend = styled.legend`
   margin-block-end: ${space[4]};
 `
 
-const Fieldset = styled.fieldset`
+const Fieldset = styled.div`
+  display: grid;
+  grid-gap: ${space[4]};
+`
+
+const InputFields = styled.div`
   display: grid;
   grid-template-columns: auto 1fr;
   column-gap: ${space[8]};
@@ -33,12 +39,16 @@ export const MoneyInput = ({
   currencyProps,
   amountProps,
   legend,
+  instruction,
 }: MoneyInputProps) => {
   return (
-    <Fieldset>
+    <Fieldset role="group">
       {legend && <Legend>{legend}</Legend>}
-      <Select {...currencyProps} variant="short" />
-      <Input {...amountProps} type="number" />
+      <InputFields>
+        <Select {...currencyProps} variant="short" />
+        <Input {...amountProps} type="number" />
+      </InputFields>
+      {instruction}
     </Fieldset>
   )
 }

--- a/src/components/MoneyInputV2/index.stories.tsx
+++ b/src/components/MoneyInputV2/index.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { Instruction } from '../Instruction'
 import { MoneyInput } from './'
 
 const currencies = [
@@ -89,6 +90,11 @@ export const Basic = () => {
           }),
         value: money.currency,
       }}
+      instruction={
+        <Instruction>
+          Lorem ipsum dolor sit amet consectetur adipisicing.
+        </Instruction>
+      }
       amountProps={{
         id: 'amount',
         'aria-label': 'Amount',
@@ -134,7 +140,12 @@ export const WithLegend = () => {
 
   return (
     <MoneyInput
-      legend="Selling price"
+      legend="Selling price for all of your amazing tickets"
+      instruction={
+        <Instruction>
+          Lorem ipsum dolor sit amet consectetur adipisicing.
+        </Instruction>
+      }
       currencyProps={{
         id: 'currency',
         options: currencies,

--- a/src/components/OneTimeCodeInputV2/OneTimeCodeInput.tsx
+++ b/src/components/OneTimeCodeInputV2/OneTimeCodeInput.tsx
@@ -42,7 +42,7 @@ interface OneTimeCodeInputProps {
   'aria-label': string
   legend?: string
   disabled?: boolean
-  instruction?: ReactElement | null
+  instruction?: ReactElement
   onChange?: ChangeEventHandler<HTMLInputElement>
   value?: string
   defaultValue?: string
@@ -55,7 +55,7 @@ export const OneTimeCodeInput = ({
   'aria-label': ariaLabel,
   legend,
   disabled = false,
-  instruction = null,
+  instruction,
   onChange,
   defaultValue = '',
   value,

--- a/src/components/PhoneInputV2/PhoneInput.tsx
+++ b/src/components/PhoneInputV2/PhoneInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import styled from '@emotion/styled'
 import { Input, InputProps } from '../InputV2'
 import { Select, SelectProps } from '../SelectV2'
@@ -8,13 +8,19 @@ export interface PhoneInputProps {
   legend?: string
   countryProps: SelectProps
   numberProps: InputProps
+  instruction?: ReactNode
 }
 
 const Legend = styled.legend`
   margin-block-end: ${space[4]};
 `
 
-const Fieldset = styled.fieldset`
+const Fieldset = styled.div`
+  display: grid;
+  grid-gap: ${space[4]};
+`
+
+const InputFields = styled.div`
   display: grid;
   grid-template-columns: auto 1fr;
   column-gap: ${space[8]};
@@ -24,12 +30,16 @@ export const PhoneInput = ({
   legend,
   countryProps,
   numberProps,
+  instruction,
 }: PhoneInputProps) => {
   return (
-    <Fieldset>
+    <Fieldset role="group">
       {legend && <Legend>{legend}</Legend>}
-      <Select {...countryProps} variant="shortvalue" />
-      <Input {...numberProps} type="tel" />
+      <InputFields>
+        <Select {...countryProps} variant="shortvalue" />
+        <Input {...numberProps} type="tel" />
+      </InputFields>
+      {instruction}
     </Fieldset>
   )
 }

--- a/src/components/PhoneInputV2/index.stories.tsx
+++ b/src/components/PhoneInputV2/index.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Flag } from '../Flag'
+import { Instruction } from '../Instruction'
 import { PhoneInput } from './'
 
 const countries = [
@@ -87,6 +88,7 @@ export const WithLegend = () => {
         options: countries,
         defaultValue: '+975',
       }}
+      instruction={<Instruction>Enter your phone number</Instruction>}
       numberProps={{
         id: 'number',
         'aria-label': 'Number',

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { space } from '../..'
 import { RadioProps } from './Radio'
 import { RadioWithLabel } from './RadioWithLabel'
 import { Label } from '../Label'
 
-const Fieldset = styled.fieldset`
+const Fieldset = styled.div`
   display: grid;
   grid-gap: ${space[4]};
 `
@@ -23,6 +23,7 @@ export interface RadioGroupProps {
   value: string
   legend?: string
   name: string
+  instruction?: ReactNode
 }
 
 export const RadioGroup = ({
@@ -31,6 +32,7 @@ export const RadioGroup = ({
   value,
   name,
   legend,
+  instruction,
 }: RadioGroupProps) => (
   <Fieldset>
     {legend && <Label as="legend">{legend}</Label>}
@@ -43,5 +45,6 @@ export const RadioGroup = ({
         {...option}
       />
     ))}
+    {instruction}
   </Fieldset>
 )

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -14,7 +14,7 @@ export interface RadioOption
   extends Omit<RadioProps, 'id' | 'value' | 'label'> {
   id: string
   value: string
-  label: string
+  label: ReactNode
 }
 
 export interface RadioGroupProps {

--- a/src/components/RadioGroup/RadioWithLabel.tsx
+++ b/src/components/RadioGroup/RadioWithLabel.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React, { forwardRef, Ref } from 'react'
+import React, { forwardRef, ReactNode, Ref } from 'react'
 import { color, radius, space } from '../..'
 import { Label } from '../Label'
 import { Radio, RadioProps } from './Radio'
@@ -18,7 +18,7 @@ const Wrapper = styled.span`
 
 export interface RadioWithLabelProps extends Omit<RadioProps, 'id'> {
   id: string
-  label: string
+  label: ReactNode
 }
 
 export const RadioWithLabel = forwardRef(

--- a/src/components/RadioGroup/index.stories.tsx
+++ b/src/components/RadioGroup/index.stories.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { RadioGroup } from '.'
+import { Instruction } from '../Instruction'
 
 export default {
   title: 'Components/Inputs/RadioGroup',
@@ -22,6 +23,7 @@ export const Basic = () => {
         { id: 'Viktor', value: 'Viktor', label: 'Viktor' },
       ]}
       value={value}
+      instruction={<Instruction>Choose your favorite (Glenn)</Instruction>}
       onChange={event => {
         console.log(event)
         setValue(event.target.value)

--- a/src/components/SelectV2/SelectWithLabel.tsx
+++ b/src/components/SelectV2/SelectWithLabel.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.span`
 
 export interface SelectWithAriaLabel extends SelectProps {
   id: string
-  instruction?: ReactElement | null
+  instruction?: ReactElement
   label?: string
 }
 
@@ -25,7 +25,7 @@ export type SelectWithLabelProps = SelectWithAriaLabel | SelectWithRequiredLabel
 
 export const SelectWithLabel = ({
   id,
-  instruction = null,
+  instruction,
   label,
   'aria-label': ariaLabel,
   ...props

--- a/src/components/Textarea/TextareaWithLabel.tsx
+++ b/src/components/Textarea/TextareaWithLabel.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.span`
 
 interface TextareaWithAriaLabel extends TextareaProps {
   id: string
-  instruction?: ReactElement | null
+  instruction?: ReactElement
   label?: string
 }
 
@@ -28,7 +28,7 @@ export type TextareaWithLabelProps =
 
 export const TextareaWithLabel = ({
   id,
-  instruction = null,
+  instruction,
   label,
   'aria-label': ariaLabel,
   ...props


### PR DESCRIPTION
# Description

This PR does a few things, such as:

* Removing the default value of `null` for instruction props
* Make the `RadioGroup` labels a `ReactNode` type
* Add instruction props to the RadioGroup, PhoneInput and MoneyInput

See commits.

## How to test

- Checkout this branch
- `yarn storybook`
- Verify the input stories are working as expected