### PR TITLE
fix(useTransition): fix types output for useTransition

### DIFF
--- a/src/hooks/useTransition/index.ts
+++ b/src/hooks/useTransition/index.ts
@@ -26,15 +26,19 @@ interface useTransitionParameters {
 
 type DefaultTransitionState = keyof typeof TransitionState
 
-export const useTransition = ({
-  in: on,
-  defaultTransitionState = TransitionState.EXITED,
-  timeout,
-  onExited = () => {},
-  onEntering = () => {},
-  onEntered = () => {},
-  onExiting = () => {},
-}: useTransitionParameters): [DefaultTransitionState, boolean, boolean] => {
+export const useTransition = (
+  props: useTransitionParameters
+): [DefaultTransitionState, boolean, boolean] => {
+  const {
+    in: on,
+    defaultTransitionState = TransitionState.EXITED,
+    timeout,
+    onExited = () => {},
+    onEntering = () => {},
+    onEntered = () => {},
+    onExiting = () => {},
+  } = props
+
   const [state, setState] = useState(defaultTransitionState)
   const [mounted, setMounted] = useState(false)
 


### PR DESCRIPTION
# Description

The use transition hook is generating a bug in the use transition types, this will make sure we're generating proper types. Need to investigate if this is a setting that we need to change or not.
