### PR TITLE
Display `Toast` with inverted colors

### DIFF
--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Toast, ToastProvider, useToast } from './'
 import { Button, ButtonSize, ButtonVariant } from '../Button'
+import { BaseButton } from '../BaseButton'
 import { Select } from '../Select'
 import styled from '@emotion/styled'
 import { CheckmarkRounded } from '../../icons'
@@ -94,13 +95,7 @@ function Persistent() {
             <ToastContent>
               <span>Payment failed</span>
 
-              <Button
-                onClick={remove}
-                size={ButtonSize.medium}
-                variant={ButtonVariant.secondary}
-              >
-                Discard
-              </Button>
+              <BaseButton onClick={remove}>Discard</BaseButton>
             </ToastContent>
           </Toast>
         ))
@@ -155,13 +150,7 @@ function PersistentWithAdornment() {
               <ToastContent>
                 <span>Saved!</span>
 
-                <Button
-                  onClick={remove}
-                  size={ButtonSize.medium}
-                  variant={ButtonVariant.secondary}
-                >
-                  Discard
-                </Button>
+                <BaseButton onClick={remove}>Discard</BaseButton>
               </ToastContent>
             </Toast>
           ))

--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -3,7 +3,6 @@ import { Toast, ToastProvider, useToast } from './'
 import { Button, ButtonSize, ButtonVariant } from '../Button'
 import { Select } from '../Select'
 import styled from '@emotion/styled'
-import { Text } from '../Text'
 import { CheckmarkRounded } from '../../icons'
 import { color, space } from '../../theme'
 import { Dialog, DialogBody, DialogHeader, DialogWindow } from '../Dialog'
@@ -22,15 +21,7 @@ function Basic() {
   const { notify } = useToast()
 
   return (
-    <Button
-      onClick={() =>
-        notify(() => (
-          <Toast>
-            <Text>Notification</Text>
-          </Toast>
-        ))
-      }
-    >
+    <Button onClick={() => notify(() => <Toast>Notification</Toast>)}>
       Show toast
     </Button>
   )
@@ -47,7 +38,7 @@ function WithAdornment() {
             persist
             leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
           >
-            <Text>Your preferences have been successfully updated</Text>
+            Your preferences have been successfully updated
           </Toast>
         ))
       }
@@ -101,7 +92,8 @@ function Persistent() {
         notify(remove => (
           <Toast persist>
             <ToastContent>
-              <Text>Payment failed</Text>
+              <span>Payment failed</span>
+
               <Button
                 onClick={remove}
                 size={ButtonSize.medium}
@@ -137,7 +129,8 @@ function PersistentWithAdornment() {
               leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
             >
               <ToastContent>
-                <Text>Your preferences have been successfully updated</Text>
+                <span>Your preferences have been successfully updated</span>
+
                 <Button
                   onClick={remove}
                   size={ButtonSize.medium}
@@ -160,7 +153,8 @@ function PersistentWithAdornment() {
               leftAdornment={<CheckmarkRounded color={color.titan} size={24} />}
             >
               <ToastContent>
-                <Text>Saved!</Text>
+                <span>Saved!</span>
+
                 <Button
                   onClick={remove}
                   size={ButtonSize.medium}
@@ -192,11 +186,7 @@ const WithDialog = () => {
             <DialogBody>
               <Button
                 onClick={() =>
-                  notify(() => (
-                    <Toast persist>
-                      <Text>Notification</Text>
-                    </Toast>
-                  ))
+                  notify(() => <Toast persist>Notification</Toast>)
                 }
               >
                 Show toast

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -48,7 +48,7 @@ export interface ToastBlockProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const ToastContainer = styled.div<ToastBlockProps>`
   border-radius: ${radius.lg};
-  background-color: ${color.elevatedBackground};
+  background-color: ${color.invertedBackground};
   box-shadow: ${shadow.strong};
   padding-block: ${space[16]};
   padding-inline: ${space[16]};
@@ -63,7 +63,7 @@ const ToastContainer = styled.div<ToastBlockProps>`
     `}
 `
 const ToastText = styled.span`
-  color: ${color.foreground};
+  color: ${color.invertedForeground};
 `
 
 interface ItemContainerStyles {


### PR DESCRIPTION
# Description
Design would like to use inverted colors for our toasts, so that they are better visible. This was already done before, and reverted, but this was probably reverted because the colors weren't correctly displayed in storybook (see https://github.com/TicketSwap/solar/issues/1507). This is because the toasts are displayed in a portal, and storybook is not handling them really great. Added #1608 to improve this.

## How to test

- Checkout this branch
- `yarn storybook`
- Go to the `Toast > Persistent` story
- Click Show Toast
- Verify the toast is displayed with a dark background color
- Enable dark mode in storybook
- Click right mouse on the Toast and inspect HTML
- Add `data-theme="dark"` to the `html` tag
- Verify the toast is having a light background

## Screenshots
<img width="1671" alt="Screenshot 2022-09-15 at 13 47 45" src="https://user-images.githubusercontent.com/14276144/190407302-b781146f-898b-46fd-bb00-7822a12a983b.png">

<img width="1662" alt="Screenshot 2022-09-15 at 13 48 09" src="https://user-images.githubusercontent.com/14276144/190407308-b39ea0b5-3ccc-4156-aa0b-b798fdc9b77f.png">

## To be notified

@Marruk 