### PR TITLE
fix(select): fix width on mobile

### DIFF
--- a/src/components/SelectV2/Select.tsx
+++ b/src/components/SelectV2/Select.tsx
@@ -63,11 +63,10 @@ const StyledSelect = styled.select<StyledSelectProps>`
   }
 
   ${props =>
-    props.variant === 'short' &&
+    props.variant.startsWith('short') &&
     css`
       position: absolute;
       inset: 0;
-      z-index: -1;
     `}
 `
 


### PR DESCRIPTION
# Description
The width on mobile was taken up by the native select html element in the shortvalue type, this one should grow and shrink based on the size of the display value instead.
