### PR TITLE
Introduce secondary action in DropZone

### DIFF
--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -1,4 +1,10 @@
-import React, { useState, ChangeEvent, DragEvent, useRef } from 'react'
+import React, {
+  useState,
+  ChangeEvent,
+  DragEvent,
+  useRef,
+  ReactNode,
+} from 'react'
 import styled from '@emotion/styled'
 import { css } from '@emotion/react'
 import {
@@ -29,6 +35,7 @@ export interface DropzoneProps {
   subtitle: string
   action: string
   mobileAction?: string
+  secondaryAction?: ReactNode
   dropTitle: string
   accept?: string[]
   multiple?: boolean
@@ -43,6 +50,10 @@ interface InformationStyles {
 }
 
 interface DropAreaStyles {
+  variant: DropzoneVariant
+}
+
+interface DesktopUIStyles {
   variant: DropzoneVariant
 }
 
@@ -78,8 +89,7 @@ const DropOverlay = styled.div<DropOverlayProps>`
 
 const DropArea = styled.div<DropAreaStyles>`
   display: flex;
-  flex-direction: ${({ variant }) =>
-    variant === DropzoneVariant.small ? 'row' : 'column'};
+  flex-direction: column;
   align-items: center;
   width: 100%;
   border-radius: ${radius.lg};
@@ -91,6 +101,8 @@ const DropArea = styled.div<DropAreaStyles>`
   background-color: ${color.elevatedBackground};
 
   @media ${device.tablet} {
+    flex-direction: ${({ variant }) =>
+      variant === DropzoneVariant.small ? 'row' : 'column'};
     background-color: ${color.actionBackground};
     border: 2px dashed ${color.earth};
   }
@@ -107,30 +119,41 @@ const Title = styled(H4)`
 const Information = styled.div<InformationStyles>`
   display: flex;
   flex-direction: column;
-  align-items: ${({ variant }) =>
-    variant === DropzoneVariant.small ? 'flex-start' : 'center'};
-  text-align: ${({ variant }) =>
-    variant === DropzoneVariant.small ? 'left' : 'center'};
+  align-items: center;
+  text-align: center;
   justify-content: center;
   padding-block-start: ${space[12]};
   flex: 1;
   gap: ${space[8]};
+
+  @media ${device.tablet} {
+    align-items: ${({ variant }) =>
+      variant === DropzoneVariant.small ? 'flex-start' : 'center'};
+    text-align: ${({ variant }) =>
+      variant === DropzoneVariant.small ? 'left' : 'center'};
+  }
 `
 
 const FileInput = styled.input`
   display: none;
 `
 
-const DesktopUI = styled.div`
+const DesktopUI = styled.div<DesktopUIStyles>`
   display: none;
 
   @media ${device.tablet} {
-    display: block;
+    display: flex;
+    flex-direction: ${({ variant }) =>
+      variant === DropzoneVariant.small ? 'row' : 'column'};
+    gap: ${({ variant }) =>
+      variant === DropzoneVariant.small ? space[32] : space[24]};
   }
 `
 
 const MobileUI = styled.div`
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: ${space[16]};
   width: 100%;
 
   @media ${device.tablet} {
@@ -146,6 +169,7 @@ export const Dropzone = ({
   title,
   subtitle,
   action,
+  secondaryAction,
   mobileAction,
   dropTitle,
   accept = ['*'],
@@ -229,7 +253,7 @@ export const Dropzone = ({
         <Information variant={variant}>
           <Title>{title}</Title>
           <SmallText>{subtitle}</SmallText>
-          <DesktopUI>
+          <DesktopUI variant={variant}>
             <BaseButton onClick={onButtonClick}>{action}</BaseButton>
             <FileInput
               type="file"
@@ -239,11 +263,13 @@ export const Dropzone = ({
               multiple={multiple}
               onChange={onSelectFile}
             />
+            {secondaryAction && <>{secondaryAction}</>}
           </DesktopUI>
           <MobileUI>
             <StyledButton onClick={onButtonClick}>
               {mobileAction ?? action}
             </StyledButton>
+            {secondaryAction && <>{secondaryAction}</>}
           </MobileUI>
         </Information>
       </>

--- a/src/components/Dropzone/index.stories.tsx
+++ b/src/components/Dropzone/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Dropzone } from '.'
-import { CloseAlt } from '../../icons'
+import { CloseAlt, File } from '../../icons'
+import { BaseButton } from '../BaseButton'
 import {
   DialogAdornment,
   DialogBody,
@@ -122,3 +123,50 @@ export const Multiple = () => {
 }
 
 Multiple.storyName = 'Accepts Multiple'
+
+export const SecondaryAction = () => {
+  const { show, hide, getWindowProps } = useDialog()
+
+  return (
+    <>
+      <DialogWindow {...getWindowProps()}>
+        <DialogHeader>
+          Help
+          <DialogAdornment right>
+            <button onClick={hide}>
+              <CloseAlt size={24} />
+            </button>
+          </DialogAdornment>
+        </DialogHeader>
+        <DialogBody>
+          <Text>
+            Since it’s not possible to download Go Mobile tickets from
+            Ticketmaster, you can upload screenshots of them instead. Each
+            screenshot must contain only one fully visible ticket.
+          </Text>
+        </DialogBody>
+      </DialogWindow>
+      <Dropzone
+        title="Upload PDF or Apple Wallet tickets"
+        subtitle="If your original file contains multiple tickets make sure to upload all of them, and we will let you select the ones you want to sell."
+        action="Drop files here or click here to select"
+        secondaryAction={
+          <BaseButton
+            leftAdornment={<File size={20} />}
+            onClick={event => {
+              event.stopPropagation()
+              show()
+            }}
+          >
+            View example
+          </BaseButton>
+        }
+        mobileAction="Select a file"
+        dropTitle="Release"
+        onFileChange={file => console.log(file)}
+      />
+    </>
+  )
+}
+
+SecondaryAction.storyName = 'Secondary Action'


### PR DESCRIPTION
# Description

This PR allows the Dropzone to have a secondary action. e.g. a help button that can be used to present useful information.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`

## Screenshots

<img width="1129" alt="Screenshot 2022-10-21 at 11 41 41" src="https://user-images.githubusercontent.com/1096800/197166893-86421af8-7d33-46ba-be5f-96d31dad3c5a.png">
<img width="1142" alt="Screenshot 2022-10-21 at 11 41 51" src="https://user-images.githubusercontent.com/1096800/197166897-434cde5c-5010-4db5-b5ec-512889ac300d.png">
<img width="828" alt="Screenshot 2022-10-21 at 11 43 19" src="https://user-images.githubusercontent.com/1096800/197166900-55a59cdb-22c5-449a-babf-492ef2f6f395.png">
<img width="716" alt="Screenshot 2022-10-21 at 11 43 29" src="https://user-images.githubusercontent.com/1096800/197166903-da3cd05d-eca7-4d9a-8ac6-b1318faa4968.png">

## To be notified
@TicketSwap/frontend 

## Links
[JIRA HG-2168](https://ticketswap.atlassian.net/browse/HG-2168)