### PR TITLE
feat: Add light variant to Dropzone

### DIFF
--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -20,6 +20,7 @@ import { SmallText } from '../Text'
 import { BaseButton } from '../BaseButton'
 import { Button } from '../Button'
 import { FilesIllustration } from './FilesIllustration'
+import { ArrowUpRounded } from '../../icons'
 
 interface DropOverlayProps {
   isDragging: boolean
@@ -28,11 +29,12 @@ interface DropOverlayProps {
 export enum DropzoneVariant {
   default = 'default',
   small = 'small',
+  light = 'light',
 }
 
 export interface DropzoneProps {
-  title: string
-  subtitle: string
+  title?: string
+  subtitle?: string
   action: string
   mobileAction?: string
   secondaryAction?: ReactNode
@@ -93,18 +95,26 @@ const DropArea = styled.div<DropAreaStyles>`
   align-items: center;
   width: 100%;
   border-radius: ${radius.lg};
-  padding-block-start: ${space[16]};
-  padding-block-end: ${space[24]};
+  padding-block-start: ${({ variant }) =>
+    variant === DropzoneVariant.light ? space[24] : space[16]};
+  padding-block-end: ${({ variant }) =>
+    variant === DropzoneVariant.light ? space[40] : space[24]};
   padding-inline: ${space[16]};
   text-align: center;
   position: relative;
-  background-color: ${color.elevatedBackground};
+  background-color: ${({ variant }) =>
+    variant === DropzoneVariant.light
+      ? 'transparent'
+      : color.elevatedBackground};
 
   @media ${device.tablet} {
     flex-direction: ${({ variant }) =>
       variant === DropzoneVariant.small ? 'row' : 'column'};
     background-color: ${color.actionBackground};
-    border: 2px dashed ${color.earth};
+    border-width: 2px;
+    border-style: dashed;
+    border-color: ${({ variant }) =>
+      variant === DropzoneVariant.light ? color.actionFocus : color.action};
   }
 `
 
@@ -159,10 +169,6 @@ const MobileUI = styled.div`
   @media ${device.tablet} {
     display: none;
   }
-`
-
-const StyledButton = styled(Button)`
-  width: 100%;
 `
 
 export const Dropzone = ({
@@ -244,15 +250,17 @@ export const Dropzone = ({
       </DropOverlay>
 
       <>
-        <StyledFilesIllustration
-          width="170px"
-          height="100px"
-          alt={dropTitle}
-          onClick={onButtonClick}
-        />
+        {variant !== DropzoneVariant.light && (
+          <StyledFilesIllustration
+            width="170px"
+            height="100px"
+            alt={dropTitle}
+            onClick={onButtonClick}
+          />
+        )}
         <Information variant={variant}>
-          <Title>{title}</Title>
-          <SmallText>{subtitle}</SmallText>
+          {title && <Title>{title}</Title>}
+          {subtitle && <SmallText>{subtitle}</SmallText>}
           <DesktopUI variant={variant}>
             <BaseButton onClick={onButtonClick}>{action}</BaseButton>
             <FileInput
@@ -266,10 +274,23 @@ export const Dropzone = ({
             {secondaryAction && <>{secondaryAction}</>}
           </DesktopUI>
           <MobileUI>
-            <StyledButton onClick={onButtonClick}>
-              {mobileAction ?? action}
-            </StyledButton>
-            {secondaryAction && <>{secondaryAction}</>}
+            {variant === DropzoneVariant.light ? (
+              <Button
+                fullWidth
+                variant="secondary"
+                leftAdornment={<ArrowUpRounded size={24} />}
+                onClick={onButtonClick}
+              >
+                {mobileAction ?? action}
+              </Button>
+            ) : (
+              <>
+                <Button fullWidth onClick={onButtonClick}>
+                  {mobileAction ?? action}
+                </Button>
+                {secondaryAction && <>{secondaryAction}</>}
+              </>
+            )}
           </MobileUI>
         </Information>
       </>

--- a/src/components/Dropzone/index.stories.tsx
+++ b/src/components/Dropzone/index.stories.tsx
@@ -47,6 +47,20 @@ export const Small = () => (
 
 Small.storyName = 'Small'
 
+export const Light = () => (
+  <>
+    <Dropzone
+      action="Drop files here or click here to select"
+      mobileAction="Select a file"
+      dropTitle="Release"
+      variant={DropzoneVariant.light}
+      onFileChange={file => console.log(file)}
+    />
+  </>
+)
+
+Light.storyName = 'Light'
+
 export const WithFileRestrictions = () => {
   const { show, hide, getWindowProps } = useDialog()
 


### PR DESCRIPTION
# Description

This PR adds a light variant to the Dropzone component.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn storybook`
- Check both the desktop and mobile versions

## Screenshots
<img width="821" alt="Screenshot 2022-11-11 at 15 19 33" src="https://user-images.githubusercontent.com/1096800/201359357-ce663eb8-c6e2-48d8-80de-beef169a49b9.png">
<img width="550" alt="Screenshot 2022-11-11 at 15 19 44" src="https://user-images.githubusercontent.com/1096800/201359361-4dbe1d5a-69ad-40ca-a573-a4053719fbd1.png">


## To be notified
@TicketSwap/frontend 

## Links
[HG-2169](https://ticketswap.atlassian.net/browse/HG-2169)

[HG-2169]: https://ticketswap.atlassian.net/browse/HG-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ