### PR TITLE
File type checking dropzone

### DIFF
--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -199,7 +199,7 @@ export const Dropzone = ({
     if (
       accept[0] !== '*' &&
       Array.from(e.dataTransfer.files).some(
-        ({ name }) => !accept.includes(`.${name.split('.')[1]}`)
+        ({ name }) => !accept.includes(`.${name.split('.').at(-1)}`)
       )
     ) {
       if (onUnacceptedFileChange) {


### PR DESCRIPTION
# Description

If we have a file name with dots, `Screenshot 2022-11-14 at 11.10.58.png`, we should only consider the last one.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`
- Upload a file with multiple dots
- See it is logged in your console log as an accepted file

## Screenshots
<img width="1279" alt="Screenshot 2022-11-14 at 17 19 39" src="https://user-images.githubusercontent.com/1096800/201711305-e4358351-8a77-4e0f-803c-8ecce0c485f9.png">


## To be notified

@TicketSwap/frontend 
