### PR TITLE
chore(Panel): replace shadow with stroke

### DIFF
--- a/src/components/Panel/index.tsx
+++ b/src/components/Panel/index.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import {
   radius,
-  shadow,
   color,
   space,
   device,
@@ -15,8 +14,7 @@ export interface PanelContentProps {
 
 export const Panel = styled.div`
   ${fullBleed};
-  background-color: ${color.background};
-  box-shadow: ${shadow.strong};
+  border: 1px solid ${color.stroke};
 
   @media ${device.mobileL} {
     ${resetFullBleed};


### PR DESCRIPTION
# Description
Moving forward, elements with no events like Panels will have a stroke instead of a shadow. If a Panel should also include e.g. a click event, we recommend using a Card instead.

## Changes
- [ ] Removed the shadow CSS property
- [ ] Added a stroke

## How to test
- [ ] Checkout this branch
- [ ] Run storybook, confirm the shadow is replaced by a border.