### PR TITLE
Revamped chip component 

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,0 +1,129 @@
+import React, { ButtonHTMLAttributes, ReactNode } from 'react'
+import styled from '@emotion/styled'
+import { css } from '@emotion/react'
+import {
+  space,
+  color,
+  device,
+  lineHeight,
+  fontSize,
+  fontWeight,
+} from '../../theme'
+
+const Content = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: auto;
+`
+
+interface ContainerProps {
+  active: boolean
+  compact: boolean
+  hasStartAdornment: boolean
+}
+
+const Container = styled.span<ContainerProps>`
+  --_accentColor: ${color.inactive};
+  --_backgroundColor: ${color.background};
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border: 2px solid var(--_accentColor);
+    border-radius: ${space[32]};
+    pointer-events: none;
+  }
+
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  padding-inline: ${space[16]};
+  padding-block: ${space[8]};
+  gap: ${space[4]};
+  background-color: var(--_backgroundColor);
+  border-radius: ${space[32]};
+  color: var(--_accentColor);
+  max-width: ${space[144]};
+  line-height: 20px;
+  font-size: ${fontSize[14]};
+  font-weight: ${fontWeight.semiBold};
+  user-select: none;
+
+  & > * {
+    pointer-events: none;
+  }
+
+  & ${Content} {
+    pointer-events: auto;
+  }
+
+  ${({ active }) =>
+    active &&
+    css`
+      --_accentColor: ${color.action};
+      --_backgroundColor: ${color.actionBackground};
+    `}
+
+  ${({ hasStartAdornment, compact }) =>
+    hasStartAdornment &&
+    compact &&
+    css`
+      > *:first-of-type {
+        display: none;
+      }
+
+      @media ${device.tablet} {
+        > *:first-of-type {
+          display: block;
+        }
+      }
+    `}
+
+  @media ${device.tablet} {
+    max-width: 240px;
+    gap: ${space[8]};
+    font-size: ${fontSize[16]};
+    line-height: ${lineHeight.copy};
+  }
+`
+
+export interface ChipProps {
+  as?: 'button' | 'label'
+  active?: boolean
+  startAdornment?: ReactNode
+  endAdornment?: ReactNode
+  compact?: boolean
+}
+
+interface ButtonChipProps
+  extends ChipProps,
+    ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Chip = ({
+  as = 'button',
+  active = false,
+  startAdornment,
+  endAdornment,
+  compact = false,
+  children,
+  ...props
+}: ButtonChipProps) => {
+  return (
+    <Container
+      as={as}
+      active={active}
+      compact={compact}
+      hasStartAdornment={Boolean(startAdornment)}
+      {...props}
+    >
+      {startAdornment}
+
+      <Content>{children}</Content>
+
+      {endAdornment}
+    </Container>
+  )
+}

--- a/src/components/Chip/ChipWithSelect.tsx
+++ b/src/components/Chip/ChipWithSelect.tsx
@@ -1,0 +1,76 @@
+import React, {
+  InputHTMLAttributes,
+  OptionHTMLAttributes,
+  useState,
+  useId,
+} from 'react'
+import styled from '@emotion/styled'
+import { ChevronDown } from '../../icons'
+import { Chip, ChipProps } from './Chip'
+
+const SelectContent = styled.select`
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  cursor: pointer;
+`
+
+type RequiredChipProps = Omit<ChipProps, 'active' | 'endAdornment'>
+
+interface ChipWithSelectProps
+  extends RequiredChipProps,
+    InputHTMLAttributes<HTMLSelectElement> {
+  options: OptionHTMLAttributes<HTMLOptionElement>[]
+}
+
+export const ChipWithSelect = ({
+  startAdornment,
+  options,
+  value: externalValue,
+  onChange,
+  compact,
+  ...props
+}: ChipWithSelectProps) => {
+  const id = useId()
+  const [internalValue, setInternalValue] = useState(
+    props.defaultValue || options[0].value
+  )
+  const value =
+    typeof externalValue !== 'undefined' ? externalValue : internalValue
+  const currentOption = options.find(
+    option => option.value === value
+  ) as OptionHTMLAttributes<HTMLOptionElement>
+
+  return (
+    <Chip
+      compact={compact}
+      active={Boolean(value)}
+      startAdornment={startAdornment}
+      endAdornment={<ChevronDown size={16} />}
+      as="label"
+    >
+      <SelectContent
+        value={value}
+        onChange={event => {
+          setInternalValue(event.target.value)
+          onChange?.(event)
+        }}
+        {...props}
+      >
+        {options.map((option, index) => (
+          <option
+            key={
+              option.id ??
+              `${id}-${option.value?.toString().replace(/[^a-z0-9]/gi, '-')}` ??
+              index
+            }
+            {...option}
+          >
+            {option.label || option.value}
+          </option>
+        ))}
+      </SelectContent>
+      {currentOption.label || currentOption.value}
+    </Chip>
+  )
+}

--- a/src/components/Chip/ChipWithToggle.tsx
+++ b/src/components/Chip/ChipWithToggle.tsx
@@ -1,0 +1,51 @@
+import React, { useState, InputHTMLAttributes } from 'react'
+import { Chip, ChipProps } from './Chip'
+import { VisuallyHidden } from '../VisuallyHidden'
+
+type RequiredChipProps = Omit<ChipProps, 'active'>
+
+export interface ChipWithToggleProps
+  extends RequiredChipProps,
+    InputHTMLAttributes<HTMLInputElement> {}
+
+export const ChipWithToggle = ({
+  startAdornment,
+  endAdornment,
+  children,
+  checked: externalChecked,
+  defaultChecked,
+  onChange,
+  compact,
+  ...props
+}: ChipWithToggleProps) => {
+  const [internalChecked, setInternalChecked] = useState(
+    defaultChecked || false
+  )
+  const value =
+    typeof externalChecked !== 'undefined' ? externalChecked : internalChecked
+
+  return (
+    <Chip
+      as="label"
+      compact={compact}
+      active={value}
+      startAdornment={startAdornment}
+      endAdornment={endAdornment}
+    >
+      <span>
+        <VisuallyHidden>
+          <input
+            type="checkbox"
+            checked={value}
+            onChange={event => {
+              setInternalChecked(previousChecked => !previousChecked)
+              onChange?.(event)
+            }}
+            {...props}
+          />
+        </VisuallyHidden>
+        {children}
+      </span>
+    </Chip>
+  )
+}

--- a/src/components/Chip/index.stories.tsx
+++ b/src/components/Chip/index.stories.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react'
+import { Chip, ChipWithSelect, ChipWithToggle } from './'
+import { ChevronDown, CalendarAlt, Trophy, Filter } from '../../icons'
+
+export default {
+  title: 'Components/Actions/Chip',
+}
+
+export const Basic = () => <Chip onClick={console.log}>Has tickets</Chip>
+
+export const Active = () => <Chip active>Today</Chip>
+
+export const Compact = () => (
+  <Chip compact startAdornment={<CalendarAlt size={24} />}>
+    Nearby
+  </Chip>
+)
+
+export const WithStartAdornment = () => (
+  <Chip startAdornment={<CalendarAlt size={24} />}>Nearby</Chip>
+)
+
+export const WithEndAdornment = () => (
+  <Chip endAdornment={<ChevronDown size={16} />}>Today</Chip>
+)
+
+export const WithAdornments = () => (
+  <Chip
+    active
+    startAdornment={<CalendarAlt size={24} />}
+    endAdornment={<ChevronDown size={16} />}
+  >
+    Clermont-Ferrand
+  </Chip>
+)
+
+export const WithIcon = () => (
+  <Chip>
+    <Filter size={24} />
+  </Chip>
+)
+
+export const WithSelectControlled = () => {
+  const [value, setValue] = useState('tomorrow')
+
+  return (
+    <ChipWithSelect
+      value={value}
+      onChange={event => setValue(event.target.value)}
+      options={[
+        { label: 'Today', value: 'today' },
+        { label: 'Tomorrow', value: 'tomorrow' },
+        { label: 'This weekend', value: 'this-weekend' },
+      ]}
+    />
+  )
+}
+
+export const WithSelectUncontrolled = () => (
+  <ChipWithSelect
+    options={[
+      { label: 'Category', value: '' },
+      { label: 'Festivals', value: 'festivals' },
+      { label: 'Concerts', value: 'concerts' },
+    ]}
+  />
+)
+
+export const WithCompactSelect = () => (
+  <ChipWithSelect
+    compact
+    startAdornment={<CalendarAlt size={24} />}
+    options={[
+      { label: 'Today', value: 'today' },
+      { label: 'Tomorrow', value: 'tomorrow' },
+      { label: 'This weekend', value: 'this-weekend' },
+    ]}
+  />
+)
+
+export const WithToggleControlled = () => {
+  const [checked, setChecked] = useState(false)
+
+  return (
+    <>
+      <div>
+        <input
+          type="checkbox"
+          onChange={event => setChecked(event.target.checked)}
+        />
+      </div>
+      <ChipWithToggle checked={checked}>Has tickets</ChipWithToggle>
+    </>
+  )
+}
+
+export const WithToggleUncontrolled = () => (
+  <ChipWithToggle
+    startAdornment={<Trophy size={24} />}
+    endAdornment={<Trophy size={24} />}
+    onChange={event => console.log(event.target.checked)}
+    defaultChecked
+  >
+    Has tickets
+  </ChipWithToggle>
+)

--- a/src/components/Chip/index.test.tsx
+++ b/src/components/Chip/index.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react'
+import { fireEvent, render, screen } from '../../../test/test.utils'
+import { Chip, ChipWithToggle, ChipWithSelect } from './'
+import { CalendarAlt, ChevronDown } from '../../icons'
+import { matchers } from '@emotion/jest'
+
+expect.extend(matchers)
+
+describe('Chip', () => {
+  it('renders without crashing', () => {
+    const { container, getByText } = render(<Chip>Has tickets</Chip>)
+    expect(container.firstChild).toBeInTheDocument()
+    expect(getByText(/Has tickets/i)).toBeInTheDocument()
+  })
+
+  describe('when the Chip is inactive', () => {
+    it('will show only the child text in inactive color', () => {
+      const { container, getByText } = render(<Chip>Has tickets</Chip>)
+
+      expect(getByText(/Has tickets/i)).toBeInTheDocument()
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        'var(--_accentColor)'
+      )
+    })
+
+    describe('when the Chip has a startAdornment and text', () => {
+      it('will show both', () => {
+        render(<Chip startAdornment={<CalendarAlt size={24} />}>Nearby</Chip>)
+
+        expect(screen.getByText(/Nearby/i)).toBeInTheDocument()
+        expect(
+          screen.getByRole('presentation', { name: 'CalendarAlt' })
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe('when the Chip has an endAdornment and text', () => {
+      it('will show both', () => {
+        render(<Chip endAdornment={<CalendarAlt size={24} />}>Nearby</Chip>)
+
+        expect(screen.getByText(/Nearby/i)).toBeInTheDocument()
+        expect(
+          screen.getByRole('presentation', { name: 'CalendarAlt' })
+        ).toBeInTheDocument()
+      })
+    })
+
+    describe('when the Chip has adornments and text', () => {
+      it('will show the 3 of them', () => {
+        render(
+          <Chip
+            startAdornment={<CalendarAlt size={24} />}
+            endAdornment={<ChevronDown size={16} />}
+          >
+            Nearby
+          </Chip>
+        )
+
+        expect(screen.getByText(/Nearby/i)).toBeInTheDocument()
+        expect(
+          screen.getByRole('presentation', { name: 'CalendarAlt' })
+        ).toBeInTheDocument()
+        expect(
+          screen.getByRole('presentation', { name: 'ChevronDown' })
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when the Chip is active', () => {
+    it('will show only the child text in active color', () => {
+      const { container, getByText } = render(<Chip active>Has tickets</Chip>)
+
+      expect(getByText(/Has tickets/i)).toBeInTheDocument()
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        'var(--_accentColor)'
+      )
+    })
+  })
+
+  describe('when the chip is a uncontrolled select', () => {
+    it('will have a default value and will be inactive', async () => {
+      const { container } = render(
+        <ChipWithSelect
+          options={[
+            { label: 'Category', value: '' },
+            { label: 'Festivals', value: 'festivals' },
+            { label: 'Concerts', value: 'concerts' },
+          ]}
+        />
+      )
+
+      const select = screen.getByRole('combobox')
+
+      const defaultOption = screen.getByRole('option', {
+        name: /Category/i,
+        hidden: true,
+      })
+
+      expect(select).toBeInTheDocument()
+      expect(defaultOption).toBeInTheDocument()
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        'var(--_accentColor)'
+      )
+    })
+
+    it('will update the internal state when an option is clicked', () => {
+      const { container } = render(
+        <ChipWithSelect
+          options={[
+            { label: 'Category', value: '' },
+            { label: 'Festivals', value: 'festivals' },
+            { label: 'Concerts', value: 'concerts' },
+          ]}
+        />
+      )
+
+      const select = screen.getByRole('combobox')
+
+      fireEvent.change(select, { target: { value: 'festivals' } })
+
+      expect(select).toHaveValue('festivals')
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        'var(--_accentColor)'
+      )
+    })
+  })
+
+  describe('when the Chip is a controlled select', () => {
+    it('will have a value selected', async () => {
+      const { container } = render(
+        <ChipWithSelect
+          value="tomorrow"
+          options={[
+            { label: 'Today', value: 'today' },
+            { label: 'Tomorrow', value: 'tomorrow' },
+            { label: 'This weekend', value: 'this-weekend' },
+          ]}
+        />
+      )
+
+      const select = screen.getByRole('combobox')
+
+      expect(select).toHaveValue('tomorrow')
+      expect(container.firstChild).toHaveStyleRule(
+        'color',
+        'var(--_accentColor)'
+      )
+    })
+
+    it('will trigger the onChange with the new value', () => {
+      const onChange = jest.fn()
+
+      render(
+        <ChipWithSelect
+          value="tomorrow"
+          onChange={event => onChange(event.target.value)}
+          options={[
+            { label: 'Today', value: 'today' },
+            { label: 'Tomorrow', value: 'tomorrow' },
+            { label: 'This weekend', value: 'this-weekend' },
+          ]}
+        />
+      )
+
+      const select = screen.getByRole('combobox')
+
+      fireEvent.change(select, { target: { value: 'this-weekend' } })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith('this-weekend')
+    })
+  })
+
+  describe('when the chip is a toogle', () => {
+    it('can be toggled', () => {
+      const { getByRole } = render(<ChipWithToggle>Has tickets</ChipWithToggle>)
+
+      expect(document.querySelector('input')).not.toBeChecked()
+      fireEvent.click(getByRole(/checkbox/i))
+      expect(document.querySelector('input')).toBeChecked()
+    })
+
+    it('can be untoggled', () => {
+      const { getByRole } = render(
+        <ChipWithToggle defaultChecked>Has tickets</ChipWithToggle>
+      )
+
+      expect(document.querySelector('input')).toBeChecked()
+      fireEvent.click(getByRole(/checkbox/i))
+      expect(document.querySelector('input')).not.toBeChecked()
+    })
+  })
+})

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,0 +1,3 @@
+export { Chip } from './Chip'
+export { ChipWithSelect } from './ChipWithSelect'
+export { ChipWithToggle } from './ChipWithToggle'


### PR DESCRIPTION
# Description
In the Browse Events epic, we aim to revamp the filters' design. To do so, new components needed to be created. The next steps will be to implement them on the browse page in sirius. 

## Changes

- Created new Chip component 
- Extended the Chip component to be a select 
- Extender the Chip component to be a toggle button 
- Added related test 

## How to test

- Checkout this branch
- `$ yarn storybook`
- Search for Chip
- Check all the stories related 
- Make sure the test passes 

## Links
https://ticketswap.atlassian.net/browse/APO-2294
