### PR TITLE
SelectV2 - Fix React warning for default value

### DIFF
--- a/src/components/SelectV2/Select.tsx
+++ b/src/components/SelectV2/Select.tsx
@@ -134,11 +134,12 @@ export const Select = ({
   onChange,
   'aria-label': ariaLabel,
   value: externalValue,
+  defaultValue,
   ...props
 }: SelectProps) => {
   const selectboxRef = useRef<HTMLSelectElement>(null)
   const [internalValue, setInternalValue] = useState(
-    props.defaultValue || options[0].value
+    defaultValue || options[0].value
   )
   const value =
     typeof externalValue !== 'undefined' ? externalValue : internalValue


### PR DESCRIPTION
# Description
This fixes a warning when you add a default value to the select instead of a value.
With this change, internally value is always used, but the user can both use default value or value and it would work uncontrolled or controlled.
