### PR TITLE
Add ability to make a dialog scrollable with fixed content height

### DIFF
--- a/src/components/Dialog/index.stories.tsx
+++ b/src/components/Dialog/index.stories.tsx
@@ -12,18 +12,21 @@ import { ContentTransition } from '../ContentTransition'
 import { Select } from '../Select'
 import { Button, ButtonVariant } from '../Button'
 import { Input } from '../InputV2'
-import { ChevronLeftAlt, CloseAlt } from '../../icons'
+import { ChevronLeftAlt, CloseAlt, MagnifyingGlass } from '../../icons'
 import { Textarea } from '../Textarea'
 import { BaseButton } from '../BaseButton'
+import { color, device, space } from '../../theme'
+import styled from '@emotion/styled'
+import { Card } from '../Card'
 
 const items = [
-  { value: 'de', name: 'German' },
-  { value: 'it', name: 'Italian' },
-  { value: 'nl', name: 'Dutch' },
-  { value: 'en', name: 'English' },
-  { value: 'hu', name: 'Hungarian' },
-  { value: 'fr', name: 'French' },
-  { value: 'es', name: 'Spanish' },
+  { value: 'de', name: 'German', flag: '🇩🇪' },
+  { value: 'it', name: 'Italian', flag: '🇮🇹' },
+  { value: 'nl', name: 'Dutch', flag: '🇳🇱' },
+  { value: 'en', name: 'English', flag: '🇬🇧' },
+  { value: 'hu', name: 'Hungarian', flag: '🇭🇺' },
+  { value: 'fr', name: 'French', flag: '🇫🇷' },
+  { value: 'es', name: 'Spanish', flag: '🇪🇸' },
 ]
 
 const BasicDialog = ({
@@ -152,6 +155,72 @@ export const WithLongBody = () => (
 )
 
 WithLongBody.storyName = 'With long body'
+
+const Search = styled.div`
+  padding: ${space[16]};
+  border-block-end: 1px solid ${color.stroke};
+
+  @media ${device.mobileL} {
+    padding-block: ${space[32]};
+    padding-inline: ${space[32]};
+  }
+`
+
+const Flex = styled.div`
+  display: flex;
+  flex-direction: column;
+  grid-gap: ${space[8]};
+
+  @media ${device.tablet} {
+    grid-gap: ${space[16]};
+  }
+`
+
+export const WithScroll = ({
+  children,
+  ...props
+}: {
+  children: ReactNode
+  persist?: boolean
+  defaultOn?: boolean
+}) => (
+  <Dialog {...props}>
+    {({ hide, getToggleProps, getWindowProps }) => (
+      <>
+        <Button {...getToggleProps()}>Show dialog</Button>
+        <DialogWindow {...getWindowProps()}>
+          <DialogHeader>
+            Dialog Title
+            {!props.persist && (
+              <DialogAdornment right>
+                <button onClick={hide}>
+                  <CloseAlt size={24} />
+                </button>
+              </DialogAdornment>
+            )}
+          </DialogHeader>
+          <Search>
+            <Input
+              id="preferredCurrency"
+              startAdornment={<MagnifyingGlass size={24} />}
+              aria-label="A search field"
+              placeholder="Search for your currency"
+            />
+          </Search>
+          <DialogBody height="375px">
+            <Flex>
+              {items.map(({ value, name, flag }) => (
+                <Card title={name} key={value} leftAdornment={flag}></Card>
+              ))}
+            </Flex>
+          </DialogBody>
+        </DialogWindow>
+      </>
+    )}
+  </Dialog>
+)
+
+WithScroll.storyName = 'With scrollable body'
 
 export const WithHook = () => <HooksDialog />
 

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -210,7 +210,12 @@ const BodyWrapper = styled.div`
   }
 `
 
-const Body = styled.div`
+interface BodyStyles {
+  height?: string
+}
+
+const Body = styled.div<BodyStyles>`
+  height: ${props => (props.height ? props.height : 'auto')};
   max-height: 50vh;
   padding-block: ${space[16]};
   padding-inline: ${space[16]};
@@ -230,7 +235,7 @@ const Body = styled.div`
     padding-block: ${space[32]};
     padding-inline: ${space[32]};
     max-height: none;
-    overflow-y: unset;
+    overflow-y: ${props => (props.height ? 'auto' : 'unset')};
     -webkit-overflow-scrolling: auto;
   }
 `
@@ -239,18 +244,17 @@ type DialogBodyProps = {
   children: ReactNode
   title?: string
   back?: string
+  height?: string
 }
 
 export const DialogBody: React.FC<DialogBodyProps> = ({
   children,
   ...props
-}) => {
-  return (
-    <BodyWrapper>
-      <Body {...props}>{children}</Body>
-    </BodyWrapper>
-  )
-}
+}) => (
+  <BodyWrapper>
+    <Body {...props}>{children}</Body>
+  </BodyWrapper>
+)
 
 export const DialogFooter = styled.footer`
   position: relative;


### PR DESCRIPTION
# Description
This PR enables the DialogBody to consume a height prop that triggers vertical scrolling.

If a `height` is passed, overflow-y is set to `auto` making the Body scroll if your content (in `children`) exceeds the height you set.

If no `height` is passed to the DialogBody component, it works as usual where the Dialog takes up the full height of the content.

When you need elements to stay fixed (e.g. a search panel), just add it the component or HTML _before_ or _after_ your DialogBody, similar as how we already use DialogFooter. The added Story is an example of this.

## How to test
- Checkout this branch
- `$ yarn dev`
- Test all the variants provided in Storybook for the Dialog on mobile & desktop (the "With scrollable body" is new)
- In `src/components/Dialog/index.stories.tsx`, play around with the content in `DialogBody` starting on line 210, and what happens when you add/remove/change the `height` prop
- Confirm that all the other variants in storybook still work as expected

## To be notified
@RobVermeer @glenngijsberts  Here's a proof of concept, interested to hear your thoughts if we think this would be a good reusable solution. I feel that allowing the user of the component to explicitly specify a (fixed) height is an intuitive way to control the behaviour of the dialog's body that can apply to various different use-cases.

## Screenshots
A dialog with longer content, as it would display today:
<img width="812" alt="image" src="https://user-images.githubusercontent.com/49148610/203560415-71524341-b3df-40a0-8270-6917e9854ff9.png">

Add a height to the DialogBody:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/49148610/203560227-685909d8-52fd-488f-9c00-c2237902fb47.png">
<img width="616" alt="image" src="https://user-images.githubusercontent.com/49148610/203560320-01fc9a2a-70d6-401b-8a3d-076ba355676f.png">