### PR TITLE
Introduce type prop on OneTimeCodeInput

### DIFF
--- a/src/components/OneTimeCodeInputV2/OneTimeCodeInput.tsx
+++ b/src/components/OneTimeCodeInputV2/OneTimeCodeInput.tsx
@@ -26,6 +26,12 @@ const OneTimeCodeContainer = styled.section`
   }
 `
 
+export enum OneTimeCodeInputType {
+  default = 'default',
+  numbersOnly = 'numbersOnly',
+  lettersOnly = 'lettersOnly',
+}
+
 type OverwrittenInputProps =
   | 'id'
   | 'aria-label'
@@ -47,6 +53,7 @@ interface OneTimeCodeInputProps {
   value?: string
   defaultValue?: string
   inputProps?: Omit<InputWithAriaLabel, OverwrittenInputProps>
+  type?: keyof typeof OneTimeCodeInputType
 }
 
 export const OneTimeCodeInput = ({
@@ -60,6 +67,7 @@ export const OneTimeCodeInput = ({
   defaultValue = '',
   value,
   inputProps = {},
+  type = OneTimeCodeInputType.default,
 }: OneTimeCodeInputProps) => {
   const [inputValues, setInputValues] = useState([
     ...defaultValue,
@@ -148,6 +156,18 @@ export const OneTimeCodeInput = ({
     const moveRight =
       event.key === 'ArrowRight' && position !== currentValues.length - 1
     const moveLeft = event.key === 'ArrowLeft'
+
+    if (type === OneTimeCodeInputType.lettersOnly) {
+      if (!event.key.match(/^[a-zA-Z]$/) && event.key !== 'Backspace') {
+        return event.preventDefault()
+      }
+    }
+
+    if (type === OneTimeCodeInputType.numbersOnly) {
+      if (!event.key.match(/^[0-9]$/) && event.key !== 'Backspace') {
+        return event.preventDefault()
+      }
+    }
 
     if (event.key === 'Backspace') {
       if (!currentValues[position]) {

--- a/src/components/OneTimeCodeInputV2/index.stories.tsx
+++ b/src/components/OneTimeCodeInputV2/index.stories.tsx
@@ -78,6 +78,82 @@ export const Controlled = () => {
   )
 }
 
+export const WithLettersOnly = () => {
+  const [value, setValue] = useState('fooba')
+
+  return (
+    <Dialog on>
+      {({ getWindowProps }) => (
+        <>
+          <DialogWindow {...getWindowProps()}>
+            <DialogHeader>One Time Code Input</DialogHeader>
+            <DialogBody>
+              <OneTimeCodeInput
+                length={6}
+                value={value}
+                id="otc-input"
+                legend="Verificationcode"
+                instruction={
+                  <Instruction>Enter your 6 letter code here</Instruction>
+                }
+                type="lettersOnly"
+                aria-label="One Time Code Input Field:"
+                onChange={event => {
+                  console.log(event)
+                  setValue(event.target.value)
+                }}
+              />
+            </DialogBody>
+            <DialogFooter>
+              <Button onClick={() => console.log('submitted')} fullWidth>
+                Submit
+              </Button>
+            </DialogFooter>
+          </DialogWindow>
+        </>
+      )}
+    </Dialog>
+  )
+}
+
+export const WithNumbersOnly = () => {
+  const [value, setValue] = useState('1234')
+
+  return (
+    <Dialog on>
+      {({ getWindowProps }) => (
+        <>
+          <DialogWindow {...getWindowProps()}>
+            <DialogHeader>One Time Code Input</DialogHeader>
+            <DialogBody>
+              <OneTimeCodeInput
+                length={6}
+                value={value}
+                id="otc-input"
+                legend="Verificationcode"
+                instruction={
+                  <Instruction>Enter your 6 digit code here</Instruction>
+                }
+                type="numbersOnly"
+                aria-label="One Time Code Input Field:"
+                onChange={event => {
+                  console.log(event)
+                  setValue(event.target.value)
+                }}
+              />
+            </DialogBody>
+            <DialogFooter>
+              <Button onClick={() => console.log('submitted')} fullWidth>
+                Submit
+              </Button>
+            </DialogFooter>
+          </DialogWindow>
+        </>
+      )}
+    </Dialog>
+  )
+}
+
 export const ShortCode = () => {
   return (
     <Dialog on>


### PR DESCRIPTION
# Description

Currently the OneTimeCodeInput can be used for various things. You could use it for numeric codes, but also codes with letters. Sometimes you know upfront that a code only consist out of numbers or letters. To improve the experience a bit, this PR adds a `type` prop that makes it possible to only accept letters, only accept numbers or both which is the default.

## How to test

- Checkout this branch
- `yarn storybook`
- Go to the stories of the OneTimeCodeInput
- Verify you can only input letters in the letters only story
- Verify you can only input numbers in the numbers only story
- Verify the other stories are still working the same    