### PR TITLE
Make it possible to use Accordion component controlled

### DIFF
--- a/src/components/Accordion/index.stories.tsx
+++ b/src/components/Accordion/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Accordion,
   AccordionItem,
@@ -67,6 +67,36 @@ export const Collapsible = () => (
     </AccordionItem>
   </Accordion>
 )
+
+export const Controlled = () => {
+  const [index, setIndex] = useState(1)
+
+  return (
+    <Accordion index={index} onChange={setIndex} collapsible>
+      <AccordionItem>
+        <AccordionButton>Do a thing</AccordionButton>
+        <AccordionPanel>
+          <p>
+            Here are some detailed instructions about doing a thing. I am very
+            complex and probably contain a lot of content, so a user can hide or
+            show me by clicking the button above.
+          </p>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionButton>Do another thing</AccordionButton>
+        <AccordionPanel>
+          <p>
+            Here are some detailed instructions about doing yet another thing.
+            There are a lot of things someone might want to do, so I am only
+            going to talk about doing that other thing. I'll let my fellow
+            accordion items go into detail about even more things.
+          </p>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  )
+}
 
 export default {
   title: 'Components/Surfaces/Accordion',

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React from 'react'
 import { device, space, color, fontWeight } from '../../theme'
 import { ChevronDown } from '../../icons'
 import styled from '@emotion/styled'
@@ -10,9 +10,8 @@ import {
   AccordionButtonProps,
 } from '@reach/accordion'
 
-export interface AccordionProps {
-  collapsible?: boolean
-  children: ReactNode
+export interface AccordionProps extends Reach.AccordionProps {
+  onChange?: (index: number) => void
 }
 
 const Accordion: React.FC<AccordionProps> = ({


### PR DESCRIPTION
# Description

When using the Accordion component in TypeScript it wasn't possible to use the underlaying `index` and `onChange` props from the Reach Accordion, because we didn't add those props (that are available on the Accordion component from Reach) to our own type. I thought it made sense to use the types from Reach it self, but their type for the `onChange` prop doesn't seem correct, because the `index` param is optional although it's always passed in the code of Reach. Created a PR to fix this [here](https://github.com/reach/reach-ui/pull/983), but in the meantime (because you never know how long it takes for a new review/release) I think it's fine to have our own type that extends the type from Reach but implements it's own `onChange` type.

This small change makes it possible to make the Accordion controlled.

## How to test

- Checkout this branch
- `yarn storybook`
- Go to the Accordion stories
- Verify the controlled one is working as expected, and fiddle around with it a bit to test
