### PR TITLE
Added name props to options of ChipWithSelect

### DIFF
--- a/src/components/Chip/ChipWithSelect.tsx
+++ b/src/components/Chip/ChipWithSelect.tsx
@@ -17,10 +17,13 @@ const SelectContent = styled.select`
 
 type RequiredChipProps = Omit<ChipProps, 'active' | 'endAdornment'>
 
+interface OptionsProps extends OptionHTMLAttributes<HTMLOptionElement> {
+  name?: string | undefined
+}
 interface ChipWithSelectProps
   extends RequiredChipProps,
     InputHTMLAttributes<HTMLSelectElement> {
-  options: OptionHTMLAttributes<HTMLOptionElement>[]
+  options: OptionsProps[]
 }
 
 export const ChipWithSelect = ({
@@ -66,7 +69,7 @@ export const ChipWithSelect = ({
             }
             {...option}
           >
-            {option.label || option.value}
+            {option.label || option.name || option.value}
           </option>
         ))}
       </SelectContent>


### PR DESCRIPTION
In theory we would have a label everywhere, but in action (in sirius) the label is actually a `name` props as it is name of the period or the city or the category. While it could be updated in the category and period filter in the frontend, the backend is returning the list of location with city name instead of city labels. This way we support both.
