### PR TITLE
fix(icon): don't use position absolute on icons

### DIFF
--- a/src/components/InputV2/Input.tsx
+++ b/src/components/InputV2/Input.tsx
@@ -109,13 +109,13 @@ export const Input = ({
     $hasStartAdornment={Boolean(startAdornment)}
     $hasEndAdornment={Boolean(endAdornment)}
   >
-    {startAdornment && <Adornment $start>{startAdornment}</Adornment>}
     <StyledInput
       $hasStartAdornment={Boolean(startAdornment)}
       $hasEndAdornment={Boolean(endAdornment)}
       $rounded={rounded}
       {...props}
     />
+    {startAdornment && <Adornment $start>{startAdornment}</Adornment>}
     {endAdornment && <Adornment>{endAdornment}</Adornment>}
   </Container>
 )

--- a/src/icons/SvgWrapper.tsx
+++ b/src/icons/SvgWrapper.tsx
@@ -7,13 +7,13 @@ export interface WrapperProps {
 }
 
 const Wrapper = styled.span<WrapperProps>`
-  display: inline-block;
+  display: inline-grid;
+  place-items: center;
   vertical-align: middle;
   width: ${props => `${props.iconSize || 32}px`};
   height: ${props => `${props.iconSize || 32}px`};
   min-width: ${props => `${props.iconSize || 32}px`};
   min-height: ${props => `${props.iconSize || 32}px`};
-  position: relative;
 
   /*
     Overwrite the color from a styled component if
@@ -23,13 +23,6 @@ const Wrapper = styled.span<WrapperProps>`
 `
 
 const InlineSvg = styled.svg`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
   color: inherit;
   fill: currentColor;
 `

--- a/src/icons/__snapshots__/index.test.tsx.snap
+++ b/src/icons/__snapshots__/index.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Icon matches snapshot 1`] = `
 <span
-  class="icon css-1x3byhy-Wrapper e1ouvt3m1"
+  class="icon css-1l0cdq-Wrapper e1ouvt3m1"
 >
   <svg
     aria-label="Download"
-    class="css-1dx98cs-InlineSvg e1ouvt3m0"
+    class="css-1ciyvsb-InlineSvg e1ouvt3m0"
     clip-rule="evenodd"
     fill-rule="evenodd"
     focusable="false"


### PR DESCRIPTION
# Description
Position relative means that the icon can be on top of other things, which is not really handy and also not needed.