### PR TITLE
fix(chipWithSelect): inactive default option

### DIFF
--- a/src/components/Chip/ChipWithSelect.tsx
+++ b/src/components/Chip/ChipWithSelect.tsx
@@ -44,7 +44,7 @@ export const ChipWithSelect = ({
   return (
     <Chip
       compact={compact}
-      active={Boolean(value)}
+      active={Boolean(value) && !options[0].value}
       startAdornment={startAdornment}
       endAdornment={<ChevronDown size={16} />}
       as="label"


### PR DESCRIPTION
# Description

A design request is to have the first element of the select (default value) as inactive 

## How to test

- Go to the storybook > chip with select controlled 
- default state should be inactive grey > if selecting something else > should become active blue 
