### PR TITLE
fix(datePicker): corrected first day of the year in calendar

### DIFF
--- a/src/components/DatePicker/CalendarDialog.tsx
+++ b/src/components/DatePicker/CalendarDialog.tsx
@@ -99,11 +99,17 @@ const CalendarDialog = ({
 
   const [selectedMonth, setSelectedMonth] = useState(initialMonth)
   const [selectedYear, setSelectedYear] = useState(initialYear)
-
   const daysInMonth = new Date(selectedYear, selectedMonth + 1, 0).getDate()
-  const firstDayOfMonth = new Date(selectedYear, selectedMonth, 1).getDay()
-
   const weekdays = getWeekdays(locale)
+
+  const firstDayOfMonth = weekdays.findIndex(
+    day =>
+      day ===
+      new Date(selectedYear, selectedMonth, 1).toLocaleDateString(locale, {
+        weekday: 'short',
+      })
+  )
+
   const months = getMonths(locale, dateRange)
   const years = getYears({
     timeFrame: timeFrame || TimeFrame.future,
@@ -150,7 +156,7 @@ const CalendarDialog = ({
     )
   }
 
-  for (let i = 1; i < firstDayOfMonth; i++) {
+  for (let i = 0; i < firstDayOfMonth; i++) {
     days.unshift(<div key={`prev-${i}`} />)
   }
 


### PR DESCRIPTION
# Description

Following [this tissue](https://ticketswap.atlassian.net/browse/TISSUE-1290), made a little investigation. The way the calendar is built didn't include the fact that for some countries a week starts on Sunday instead of Monday. Therefore 1 Jan 2023 would show on a Monday instead of the correct sunday. This PR is correcting that bug, by finding the index of the day within the weekdays array, and unshifting the correct amount of day to show a correct calendar. 

## How to test

- Open storybook > datePicker story > open calendar > you will see that jan 1 is on monday in the calendar 
- checkout this branch 
- reopen the calendar > make sure January 2023 starts on a sunday 
- check the following years 
