### PR TITLE
fix(chip): fix style element showing when styled start adornment is used

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -71,12 +71,12 @@ const Container = styled.span<ContainerProps>`
     hasStartAdornment &&
     compact &&
     css`
-      > *:first-of-type {
+      > *:first-of-type:not(style) {
         display: none;
       }
 
       @media ${device.tablet} {
-        > *:first-of-type {
+        > *:first-of-type:not(style) {
           display: block;
         }
       }


### PR DESCRIPTION
# Description
When there is a start adornment that is styled, there are 2 elements, one being the adornment and one being the style that is applied to it. That style element should not be displayed on desktop.