### PR TITLE
fix: Allow Dropzone to be used in forms

### DIFF
--- a/src/components/BaseButton/index.tsx
+++ b/src/components/BaseButton/index.tsx
@@ -16,7 +16,8 @@ export enum BaseButtonSize {
   small = 'small',
 }
 
-export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   leftAdornment?: ReactNode
   variant?: keyof typeof ButtonVariant
   disabled?: boolean
@@ -27,14 +28,14 @@ const StyledButton = styled.button<ButtonProps>`
   ${baseTextStyles};
   position: relative;
   display: inline-block;
-  color: ${p =>
-    p.disabled
+  color: ${props =>
+    props.disabled
       ? color.inactive
-      : p.variant === ButtonVariant.success
+      : props.variant === ButtonVariant.success
       ? color.success
-      : p.variant === ButtonVariant.danger
+      : props.variant === ButtonVariant.danger
       ? color.failure
-      : p.variant === ButtonVariant.warning
+      : props.variant === ButtonVariant.warning
       ? color.warning
       : color.info};
   font-weight: ${fontWeight.semiBold};
@@ -68,15 +69,15 @@ const StyledButton = styled.button<ButtonProps>`
     background-color: transparent;
     border-radius: ${radius.md};
     opacity: 0.6;
-    box-shadow: 0 0 0 ${space[4]}
-      ${p =>
-        p.variant === ButtonVariant.success
-          ? color.success
-          : p.variant === ButtonVariant.danger
-          ? color.failure
-          : p.variant === ButtonVariant.warning
-          ? color.warning
-          : color.info};
+    box-shadow: 0 0 0 ${space[4]};
+    ${({ variant }) =>
+      variant === ButtonVariant.success
+        ? color.success
+        : variant === ButtonVariant.danger
+        ? color.failure
+        : variant === ButtonVariant.warning
+        ? color.warning
+        : color.info};
 
     @media ${device.tablet} {
       top: -2px;

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -135,6 +135,7 @@ const Information = styled.div<InformationStyles>`
   padding-block-start: ${space[12]};
   flex: 1;
   gap: ${space[8]};
+  width: 100%;
 
   @media ${device.tablet} {
     align-items: ${({ variant }) =>
@@ -262,7 +263,9 @@ export const Dropzone = ({
           {title && <Title>{title}</Title>}
           {subtitle && <SmallText>{subtitle}</SmallText>}
           <DesktopUI variant={variant}>
-            <BaseButton onClick={onButtonClick}>{action}</BaseButton>
+            <BaseButton type="button" onClick={onButtonClick}>
+              {action}
+            </BaseButton>
             <FileInput
               type="file"
               aria-label={ariaLabel}
@@ -276,6 +279,7 @@ export const Dropzone = ({
           <MobileUI>
             {variant === DropzoneVariant.light ? (
               <Button
+                type="button"
                 fullWidth
                 variant="secondary"
                 leftAdornment={<ArrowUpRounded size={24} />}
@@ -285,7 +289,7 @@ export const Dropzone = ({
               </Button>
             ) : (
               <>
-                <Button fullWidth onClick={onButtonClick}>
+                <Button type="button" fullWidth onClick={onButtonClick}>
                   {mobileAction ?? action}
                 </Button>
                 {secondaryAction && <>{secondaryAction}</>}


### PR DESCRIPTION
# Description

If the button type is not specified the form is submitted immediately. Besides this, we should allow the button to be full width within forms.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`

## Screenshots

<img width="670" alt="Screenshot 2023-01-25 at 13 15 50" src="https://user-images.githubusercontent.com/1096800/214561147-046a6495-d680-483b-b586-dfb48e743e4e.png">

## Links

[HG-2169](https://ticketswap.atlassian.net/browse/HG-2169)

[HG-2169]: https://ticketswap.atlassian.net/browse/HG-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ