### PR TITLE
React 18 Strict Mode - `useIsMounted`

### DIFF
--- a/src/components/DatePicker/index.test.tsx
+++ b/src/components/DatePicker/index.test.tsx
@@ -196,7 +196,7 @@ describe('DatePicker', () => {
         />
       )
 
-      expect(screen.getByText(/1 feb. 2020/i)).toBeInTheDocument()
+      expect(screen.getByText(/1 feb\.? 2020/i)).toBeInTheDocument()
     })
   })
 

--- a/src/hooks/useIsMounted/index.ts
+++ b/src/hooks/useIsMounted/index.ts
@@ -5,6 +5,8 @@ export const useIsMounted = (): (() => boolean) => {
   const isMounted = useCallback(() => isMountedRef.current, [])
 
   useEffect(() => {
+    isMountedRef.current = true
+
     return () => void (isMountedRef.current = false)
   }, [])
 


### PR DESCRIPTION
# Description

This PR allows the useIsMounted hook to be used within apps that use react 18's strict mode. Read more about this [here](https://coderpad.io/blog/development/why-react-18-broke-your-app/#:~:text=What%20changed%20in%20React%2018%3F)

## How to test

- Checkout this branch
- Create a build
- Put sirius to strict mode
- Use the build instead of solar package
- Confirm a toast is working

## To be notified

@RobVermeer 
