### PR TITLE
fix(Dropzone): Re-add border

### DIFF
--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -111,7 +111,7 @@ const DropArea = styled.div<DropAreaStyles>`
     flex-direction: ${({ variant }) =>
       variant === DropzoneVariant.small ? 'row' : 'column'};
     background-color: ${color.actionBackground};
-    border-inline-size: 2px;
+    border-width: 2px;
     border-style: dashed;
     border-color: ${({ variant }) =>
       variant === DropzoneVariant.light ? color.actionFocus : color.action};


### PR DESCRIPTION
# Description

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Margins_borders_padding `border-width` doesn't have a logical equivalent and is a valid property.

## Changes

- [x] This has been done
- [ ] I still need to to this

## How to test

- Checkout this branch
- `$ yarn dev`

## Screenshots
**Before**
<img width="954" alt="Screenshot 2023-04-03 at 16 01 53" src="https://user-images.githubusercontent.com/1096800/229532706-71f24eb5-8ad2-49ab-8963-b94d461d4b51.png">

**After**
<img width="961" alt="Screenshot 2023-04-03 at 15 59 57" src="https://user-images.githubusercontent.com/1096800/229532561-651d0112-656b-4ec1-9a6d-06020b157d0e.png">


## To be notified
@TicketSwap/frontend 

## Links
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Margins_borders_padding 