### PR TITLE
fix(Toast): fix re-render issues of notify

### DIFF
--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -171,7 +171,7 @@ const WithDialog = () => {
 
   return (
     <Dialog>
-      {({ hide, getToggleProps, getWindowProps }) => (
+      {({ getToggleProps, getWindowProps }) => (
         <>
           <Button {...getToggleProps()}>Show dialog</Button>
           <DialogWindow {...getWindowProps()}>


### PR DESCRIPTION
# Description
There were a few issues with the notify method of the toast provider, one of them was that the notify method was not being memoized correctly and the other problem was that we didn't set the state correctly when adding a new item, aka when notifying. This fixes the problem.

# How to test
* Go to the Toast story
* Verify it works as expected
* `console.log` the `notify` method and verify it doesn't log after showing a toast  