### PR TITLE
Align BaseButton types with Button types in order to support `as` prop

### DIFF
--- a/src/components/BaseButton/index.stories.tsx
+++ b/src/components/BaseButton/index.stories.tsx
@@ -19,6 +19,14 @@ export const Basic = () => (
   </ButtonWrapper>
 )
 
+export const AsLink = () => (
+  <ButtonWrapper>
+    <BaseButton as="a" href="https://www.ticketswap.com">
+      TicketSwap website
+    </BaseButton>
+  </ButtonWrapper>
+)
+
 export const WithIcon = () => (
   <ButtonWrapper>
     <BaseButton leftAdornment={<File size={24} />}>View example</BaseButton>

--- a/src/components/BaseButton/index.tsx
+++ b/src/components/BaseButton/index.tsx
@@ -22,6 +22,8 @@ export interface ButtonProps
   variant?: keyof typeof ButtonVariant
   disabled?: boolean
   size?: keyof typeof BaseButtonSize
+  as?: 'a'
+  href?: string
 }
 
 const StyledButton = styled.button<ButtonProps>`

--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -171,7 +171,7 @@ const WithDialog = () => {
 
   return (
     <Dialog>
-      {({ hide, getToggleProps, getWindowProps }) => (
+      {({ getToggleProps, getWindowProps }) => (
         <>
           <Button {...getToggleProps()}>Show dialog</Button>
           <DialogWindow {...getWindowProps()}>


### PR DESCRIPTION
# Description

To use styles from a styled component but change the element that's rendered, you can use the as prop which is an API of emotion. Because we didn't include those types, it wasn't possible for TypeScript files. This makes that possible.

## How to test

- Checkout this branch
- `$ yarn storybook`
- Verify the new BaseButton story of "As Link" is working as expected
