### PR TITLE
feat(Cover): Make it possible to pass ReactElement as subtitle

### DIFF
--- a/src/components/CoverV2/Cover.tsx
+++ b/src/components/CoverV2/Cover.tsx
@@ -167,7 +167,7 @@ const MetaInfo = styled.div`
 
 interface CoverProps {
   title: string
-  subtitle?: string
+  subtitle?: string | ReactElement
   images?: CoverImages
   graphic?: ReactElement
   metaInfo?: ReactElement


### PR DESCRIPTION
# Description

This makes it possible to pass a ReactElement to the subtitle of the cover, for example if you want to pass a component that handles some logic for the subtitle.

## How to test

- Checkout this branch
- `yarn storybook`
- Verify the examples work as expected