### PR TITLE
fix(theme): Fixed odd shadow/overlay colors in theme

### DIFF
--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -56,7 +56,7 @@ export const globalStyles = css`
     --stardust900: #1a2129;
     --nova: #ffffff;
     --space: #00131a;
-    --overlay: #1a212999;
+    --overlay: #00000099;
 
     // Brand
     --brand: var(--earth400);
@@ -111,9 +111,7 @@ export const globalStyles = css`
     --accent: var(--mars400);
     --stroke: var(--stardust300);
     --strokeStrong: var(--stardust400);
-    --shadow: var(--stardust500);
-    --shadowLighter: var(--stardust200);
-
+    --shadow: var(--stardust900);
     --invertedForeground: var(--nova);
     --invertedBackground: var(--stardust900);
 
@@ -192,8 +190,7 @@ export const globalStyles = css`
     --accent: var(--mars400);
     --stroke: var(--stardust800);
     --strokeStrong: var(--stardust700);
-    --shadow: var(--space);
-    --shadowLighter: rgba(0, 19, 25, 0.9);
+    --shadow: var(--stardust900);
     --invertedForeground: var(--stardust900);
     --invertedBackground: var(--nova);
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -71,9 +71,9 @@ export const fontSize = {
 } as const
 
 export const shadow = {
-  text: `0 1px 0 var(--shadowLighter)`,
-  light: `0 1px 4px var(--shadowLighter)`,
-  strong: `0 1px 2px var(--shadowLighter), 0 4px 12px var(--shadowLighter)`,
+  text: `0 1px 0 var(--shadow)`,
+  light: `0 1px 4px var(--shadow)`,
+  strong: `0 1px 2px var(--shadow), 0 4px 12px var(--shadow)`,
 } as const
 
 export const space = {


### PR DESCRIPTION
This should fix two things:
* A light glow instead of a shadow in light mode
* Overlays not having a clear outline on the overlay in dark mode