### PR TITLE
Revert the color of lightForegroundMuted

### DIFF
--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -125,7 +125,7 @@ export const globalStyles = css`
     --lightBackground: var(--nova);
     --lightElevatedBackground: var(--stardust100);
     --lightForeground: var(--nova);
-    --lightForegroundMuted: #ffffffcc;
+    --lightForegroundMuted: var(--stardust500);
     --darkBackground: var(--stardust900);
     --darkElevatedBackground: var(--space);
     --darkForeground: var(--stardust900);


### PR DESCRIPTION
# Description

The new lightForegroundMuted color was white with some opacity, but that doesn't work nice on light (white, light grey) backgrounds because it's not visible. Now reverting to mitigate the issue. Will create another PR to fix the issue properly.