### PR TITLE
fix(theme): Tweak shadow colors (properly this time)

### DIFF
--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -111,8 +111,7 @@ export const globalStyles = css`
     --accent: var(--mars400);
     --stroke: var(--stardust300);
     --strokeStrong: var(--stardust400);
-    --shadow: var(--stardust500);
-    --shadowLighter: var(--stardust200);
+    --shadow: #1a21291a;
     --invertedForeground: var(--nova);
     --invertedBackground: var(--stardust900);
 
@@ -191,8 +190,7 @@ export const globalStyles = css`
     --accent: var(--mars400);
     --stroke: var(--stardust800);
     --strokeStrong: var(--stardust700);
-    --shadow: var(--space);
-    --shadowLighter: rgba(0, 19, 25, 0.9);
+    --shadow: #00000073;
     --invertedForeground: var(--stardust900);
     --invertedBackground: var(--nova);
 

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -204,11 +204,11 @@ export const globalStyles = css`
     --lightBackground: var(--nova);
     --lightElevatedBackground: var(--stardust100);
     --lightForeground: var(--nova);
-    --lightForegroundMuted: var(--stardust500);
+    --lightForegroundMuted: #ffffffcc;
     --darkBackground: var(--stardust900);
     --darkElevatedBackground: var(--space);
     --darkForeground: var(--stardust900);
-    --darkForegroundMuted: var(--stardust600);
+    --darkForegroundMuted: #1a2129cc;
 
     // Gradients
     --linearGradientDark: rgba(26, 33, 41, 0.6) 0%, rgba(26, 33, 41, 0) 100%;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -71,9 +71,9 @@ export const fontSize = {
 } as const
 
 export const shadow = {
-  text: `0 1px 0 var(--shadowLighter)`,
-  light: `0 1px 4px var(--shadowLighter)`,
-  strong: `0 1px 2px var(--shadowLighter), 0 4px 12px var(--shadowLighter)`,
+  text: `0 1px 0 var(--shadow)`,
+  light: `0 1px 4px var(--shadow)`,
+  strong: `0 1px 2px var(--shadow), 0 4px 12px var(--shadow)`,
 } as const
 
 export const space = {


### PR DESCRIPTION
Tweak the shadow colors to match Figma and get rid of the white glow in light mode.

Looks like this now:
![Screenshot 2023-05-03 at 14 33 20](https://user-images.githubusercontent.com/6670305/235917162-53c9422f-1e9e-4abe-8d55-02c2e01ab70a.JPG)
![Screenshot 2023-05-03 at 14 33 24](https://user-images.githubusercontent.com/6670305/235917143-3036f1c2-f679-4982-9970-492e3d1805e1.JPG)