### PR TITLE
Revert new `actionBackground` color and re-introduce as `actionBackgroundAlpha12` color

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -165,7 +165,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   ${({ variant }) =>
     variant === ButtonVariant.secondary &&
     css`
-      background-color: ${color.actionBackground};
+      background-color: ${color.actionBackgroundAlpha12};
       color: ${color.action};
       background-image: unset;
 

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -73,7 +73,7 @@ export const globalStyles = css`
 
     // Action
     --action: var(--earth400);
-    --actionBackground: #00b6f01f;
+    --actionBackground: var(--earth50);
     --onAction: var(--nova);
     --actionFocus: #00b6f052;
 
@@ -158,7 +158,7 @@ export const globalStyles = css`
 
     // Action
     --action: var(--earth400);
-    --actionBackground: #00b6f01f;
+    --actionBackground: var(--earth800);
     --onAction: var(--nova);
 
     // Success

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -76,6 +76,7 @@ export const globalStyles = css`
     --actionBackground: var(--earth50);
     --onAction: var(--nova);
     --actionFocus: #00b6f052;
+    --actionBackgroundAlpha12: #00b6f01f;
 
     // Success
     --success: var(--titan400);

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -12,6 +12,7 @@ export const color = {
   actionBackground: 'var(--actionBackground)',
   onAction: 'var(--onAction)',
   actionFocus: 'var(--actionFocus)',
+  actionBackgroundAlpha12: 'var(--actionBackgroundAlpha12)',
   success: 'var(--success)',
   successBackground: 'var(--successBackground)',
   onSuccess: 'var(--onSuccess)',


### PR DESCRIPTION
# Description

The new `actionBackground` color was causing some style issues, for example for Select components where elements were visible when options were hovered. This PR reverts the new color and re-introduce it as a `actionBackgroundAlpha12` so we can use it for the secondary variant of the button, where it was introduced for.

After talking with Mark we came up with a naming pattern for transparant colors. Calling it name + `Alpha12`, to make it clear that it contains opacity and in this case 0.12. (see https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4)

## How to test

- Checkout this branch
- `$ yarn storybook`
- Verify everything works as expected

## Screenshots

<img width="1072" alt="CleanShot 2023-05-05 at 12 25 46@2x" src="https://user-images.githubusercontent.com/14276144/236434341-d206622c-5af5-4e8c-95d4-e932550f328a.png">

<img width="1086" alt="CleanShot 2023-05-05 at 12 26 20@2x" src="https://user-images.githubusercontent.com/14276144/236434465-c9713d24-c136-41a3-a34a-6c20623f6620.png">

