### PR TITLE
Clean-up semantic colors using color-mix

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,11 +6,13 @@ import {
   fontSize,
   fontWeight,
   lineHeight,
+  opacity,
   radius,
   space,
 } from '../../theme'
 import { css } from '@emotion/react'
 import { Spinner } from '../Spinner'
+import { transparentize, transparentGradient } from '../../utils/colors'
 
 export enum ButtonVariant {
   primary = 'primary',
@@ -67,11 +69,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   justify-content: center;
   font-family: inherit;
   font-weight: ${fontWeight.semiBold};
-  background-image: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.24),
-    rgba(255, 255, 255, 0)
-  );
+  background-image: ${transparentGradient('currentColor', 'to bottom', .24, 0)};
   line-height: ${lineHeight.solid};
   align-items: center;
 
@@ -86,7 +84,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     inset: -1px;
     background-color: transparent;
     border-radius: calc(${radius.md} + 1px);
-    box-shadow: 0 0 0 ${space[4]} ${color.actionFocus};
+    outline: ${space[4]} solid ${transparentize(color.action, opacity.statusFocusColor)};
     pointer-events: none;
   }
 
@@ -96,11 +94,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   }
 
   &:hover {
-    background-image: linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.48),
-      rgba(255, 255, 255, 0.24)
-    );
+    background-image: ${transparentGradient('currentColor', 'to bottom', .48, .24)};
   }
 
   ${({ disabled }) =>
@@ -165,12 +159,12 @@ const StyledButton = styled.button<StyledButtonProps>`
   ${({ variant }) =>
     variant === ButtonVariant.secondary &&
     css`
-      background-color: ${color.actionBackgroundAlpha12};
+      background-color: ${color.actionBackground};
       color: ${color.action};
       background-image: unset;
 
       &:hover {
-        background-image: unset;
+        background-image: ${transparentGradient('currentColor', 'to top', .2, .1)};
       }
     `};
 
@@ -179,13 +173,14 @@ const StyledButton = styled.button<StyledButtonProps>`
     css`
       background-color: ${color.failureBackground};
       color: ${color.failure};
+      background-image: unset;
 
-      [data-theme='dark'] & {
-        background-image: unset;
+      &:hover {
+        background-image: ${transparentGradient('currentColor', 'to top', .2, .1)};
       }
 
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} ${color.failureFocus};
+        outline-color: ${transparentize(color.failure, opacity.statusFocusColor)};
       }
     `};
 
@@ -196,7 +191,7 @@ const StyledButton = styled.button<StyledButtonProps>`
       color: ${color.onSuccess};
 
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} ${color.successFocus};
+        outline-color: ${transparentize(color.success, opacity.statusFocusColor)};
       }
     `};
 
@@ -207,7 +202,7 @@ const StyledButton = styled.button<StyledButtonProps>`
       color: ${color.onWarning};
 
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} ${color.warningFocus};
+        outline-color: ${transparentize(color.warning, opacity.statusFocusColor)};
       }
     `};
 
@@ -218,7 +213,7 @@ const StyledButton = styled.button<StyledButtonProps>`
       color: ${color.onFailure};
 
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} ${color.failureFocus};
+        outline-color: ${transparentize(color.failure, opacity.statusFocusColor)};
       }
     `};
 
@@ -227,9 +222,14 @@ const StyledButton = styled.button<StyledButtonProps>`
     css`
       background-color: ${color.background};
       color: ${color.action};
+      background-image: unset;
 
       [data-theme='dark'] & {
         background-image: unset;
+      }
+
+      &:hover {
+        background-image: ${transparentGradient('currentColor', 'to top', .2, .1)};
       }
     `};
 
@@ -240,7 +240,7 @@ const StyledButton = styled.button<StyledButtonProps>`
       color: #ffffff;
 
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} #1777f252;
+        outline-color: ${transparentize('#1777f2', opacity.statusFocusColor)};
       }
     `};
 
@@ -250,14 +250,8 @@ const StyledButton = styled.button<StyledButtonProps>`
       background-color: ${color.foreground};
       color: ${color.background};
 
-      [data-theme='dark'] & {
-        &:focus::after {
-          box-shadow: 0 0 0 ${space[4]} #ffffff52;
-        }
-      }
-
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} #1a212952;
+        outline-color: ${transparentize(color.foreground, opacity.statusFocusColor)};
       }
     `};
 
@@ -269,8 +263,12 @@ const StyledButton = styled.button<StyledButtonProps>`
       border: 1px solid ${color.lightElevatedBackground};
       background-image: unset;
 
+      &:hover {
+        background-image: ${transparentGradient('currentColor', 'to top', .1, 0)};
+      }
+
       &:focus::after {
-        box-shadow: 0 0 0 ${space[4]} #ccd0d152;
+        outline-color: ${transparentize('#ccd0d1', opacity.statusFocusColor)};
       }
     `};
 `

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -10,7 +10,9 @@ import {
   fontWeight,
   device,
   lineHeight,
+  opacity,
 } from '../../theme'
+import { transparentize } from '../../utils/colors'
 
 export enum CardVerticalAlign {
   top = 'top',
@@ -80,8 +82,7 @@ const Container = styled.div<StyledCardProps>`
   }
 
   &:focus {
-    box-shadow: 0 0 0 ${space[4]} ${color.actionFocus};
-    outline: 0;
+    outline: ${space[4]} solid ${transparentize(color.action, opacity.statusFocusColor)};
   }
 `
 

--- a/src/components/Dropzone/Dropzone.tsx
+++ b/src/components/Dropzone/Dropzone.tsx
@@ -21,6 +21,7 @@ import { BaseButton } from '../BaseButton'
 import { Button } from '../Button'
 import { FilesIllustration } from './FilesIllustration'
 import { ArrowUpRounded } from '../../icons'
+import { transparentize } from '../../utils/colors'
 
 interface DropOverlayProps {
   isDragging: boolean
@@ -114,7 +115,7 @@ const DropArea = styled.div<DropAreaStyles>`
     border-width: 2px;
     border-style: dashed;
     border-color: ${({ variant }) =>
-      variant === DropzoneVariant.light ? color.actionFocus : color.action};
+      variant === DropzoneVariant.light ? transparentize(color.action, .5) : color.action};
   }
 `
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -13,8 +13,10 @@ import {
   radius,
   device,
   fontWeight,
+  opacity,
 } from '../../theme'
 import { CloseRounded } from '../../icons'
+import { transparentize } from '../../utils/colors'
 
 export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
   id: string
@@ -109,8 +111,9 @@ export const fieldStyles = (props: InputProps) => css`
     background-color: ${props.invalid
       ? color.failureBackground
       : color.elevatedBackground};
-    box-shadow: 0 0 0 ${space[4]}
-      ${props.invalid ? color.failureFocus : color.actionFocus};
+    outline: ${space[4]} solid
+      ${props.invalid ? color.failureFocus :
+          transparentize(color.action, opacity.statusFocusColor)};
   }
 
   &::placeholder {

--- a/src/components/RadioGroup/Radio.tsx
+++ b/src/components/RadioGroup/Radio.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
 import React, { forwardRef, InputHTMLAttributes, Ref } from 'react'
-import { color, space, transition } from '../..'
+import { color, opacity, space, transition } from '../..'
 import { Checkmark } from '../../icons'
+import { transparentize } from '../../utils/colors'
 
 const Container = styled.span`
   position: relative;
@@ -46,8 +47,7 @@ const StyledInput = styled.input`
 
   &:focus,
   &:active {
-    outline: 0;
-    box-shadow: 0 0 0 ${space[4]} ${color.actionFocus};
+    outline: ${space[4]} solid ${transparentize(color.action, opacity.statusFocusColor)};
   }
 `
 

--- a/src/components/Toggle/Switch.tsx
+++ b/src/components/Toggle/Switch.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import styled from '@emotion/styled'
 import { Spinner } from '../Spinner'
-import { space, color } from '../../theme'
+import { space, color, opacity } from '../../theme'
+import { transparentize } from '../../utils/colors'
 
 export interface SwitchProps {
   on: boolean
@@ -76,7 +77,7 @@ const Button = styled.button<ButtonProps>`
     inset: -1px;
     background-color: transparent;
     border-radius: ${space[32]};
-    box-shadow: 0 0 0 ${space[4]} ${color.actionFocus};
+    outline: ${space[4]} solid ${transparentize(color.action, opacity.statusFocusColor)};
     pointer-events: none;
   }
 `

--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react'
-import { space, radius, color } from './theme'
+import { space, radius, color, opacity } from './theme'
 import { baseTextStyles } from './components/Text'
+import { transparentize } from './utils/colors'
 
 export const globalStyles = css`
   :root {
@@ -73,10 +74,8 @@ export const globalStyles = css`
 
     // Action
     --action: var(--earth400);
-    --actionBackground: var(--earth50);
+    --actionBackground: ${transparentize(color.action, opacity.statusBackgroundColor)};
     --onAction: var(--nova);
-    --actionFocus: #00b6f052;
-    --actionBackgroundAlpha12: #00b6f01f;
 
     // Success
     --success: var(--titan400);
@@ -100,7 +99,6 @@ export const globalStyles = css`
     --info: var(--earth400);
     --infoBackground: var(--earth50);
     --onInfo: var(--nova);
-    --actionFocus: #00b6f052;
 
     // Inactive
     --inactive: var(--stardust500);
@@ -292,7 +290,7 @@ export const globalStyles = css`
 
     &:focus {
       outline: 0;
-      box-shadow: 0 0 0 ${space[4]} ${color.actionFocus};
+      box-shadow: 0 0 0 ${space[4]} ${transparentize('currentColor', opacity.statusFocusColor)};
     }
   }
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -11,8 +11,6 @@ export const color = {
   action: 'var(--action)',
   actionBackground: 'var(--actionBackground)',
   onAction: 'var(--onAction)',
-  actionFocus: 'var(--actionFocus)',
-  actionBackgroundAlpha12: 'var(--actionBackgroundAlpha12)',
   success: 'var(--success)',
   successBackground: 'var(--successBackground)',
   onSuccess: 'var(--onSuccess)',
@@ -52,6 +50,11 @@ export const color = {
   darkForeground: 'var(--darkForeground)',
   darkForegroundMuted: 'var(--darkForegroundMuted)',
   overlay: 'var(--overlay)',
+} as const
+
+export const opacity = {
+  statusBackgroundColor: .1,
+  statusFocusColor: .5
 } as const
 
 export const fontStack = `'Proxima Nova', -apple-system, BlinkMacSystemFont,

--- a/src/utils/colors/index.ts
+++ b/src/utils/colors/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Utility function to apply transparency to a color (variable) using `color-mix`
+ * @param {string} color - The color to make transparent. Can be a theme variabale, a hex code or "currentColor"
+ * @param {number} opacity - The desired opacity, a number between 0 and 1
+ */
+export const transparentize = (color: string, opacity: number) => {
+  const parsedColor = color === 'currentColor' ? 'currentColor' :
+                      color.charAt(0) === '#' ? color : 
+                      color.indexOf('var(--') !== -1 ? color : `var(--${color})`
+  
+  const parsedOpacity = 100 - (opacity * 100)
+
+  return `color-mix(in srgb, ${parsedColor}, transparent ${parsedOpacity}%)`
+}
+
+export const transparentGradient = (color: string, direction: string, fromOpacity: number, toOpacity: number) => {
+  const parsedColor = color === 'currentColor' ? 'currentColor' :
+                      color.charAt(0) === '#' ? color : 
+                      color.indexOf('var(--') !== -1 ? color : `var(--${color})`
+  
+  const parsedFromOpacity = 100 - (fromOpacity * 100)
+  const parsedToOpacity = 100 - (toOpacity * 100)
+
+  return `linear-gradient(
+            ${direction},
+            color-mix(in srgb, ${parsedColor}, transparent ${parsedFromOpacity}%),
+            color-mix(in srgb, ${parsedColor}, transparent ${parsedToOpacity}%)
+          )`
+}


### PR DESCRIPTION
Recently [color-mix ](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) got supported by all major browsers.

It has the potential to clean up our semantic colour set by basing variants on a smaller set of base colours. [Some more context here](https://ticketswap.slack.com/archives/C04CDGRKZHR/p1684849529305089).

This PR is a POC taking the `actionBackground` and `actionFocus` as examples.

I added two [utility functions ](https://github.com/TicketSwap/solar/pull/1741/files#diff-5a9ad551a7556d6307d690b38037ae144ae6b6b02626c742a94503c8e36ab58b) to keep the code cleaner as the syntax of `color-mix` is a bit long, but those are optional of course.