### PR TITLE
Add "text-wrap: balance" to Cover and Prompt

### DIFF
--- a/src/components/CoverV2/Cover.tsx
+++ b/src/components/CoverV2/Cover.tsx
@@ -155,6 +155,7 @@ const Titles = styled.div`
 
 const Title = styled(H1)`
   color: var(--_coverTitleColor, ${color.lightForeground});
+  text-wrap: balance;
 `
 
 const Subtitle = styled(H2)`
@@ -162,6 +163,7 @@ const Subtitle = styled(H2)`
   font-weight: ${fontWeight.regular};
   font-size: ${fontSize[20]};
   line-height: ${lineHeight.title};
+  text-wrap: balance;
 
   @media ${device.tablet} {
     font-size: ${fontSize[24]};

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -28,6 +28,7 @@ const TextContent = styled.div`
 
 const Title = styled(H3)`
   font-weight: ${fontWeight.semiBold};
+  text-wrap: balance;
 
   @media ${device.tablet} {
     font-size: ${space[24]};
@@ -36,6 +37,7 @@ const Title = styled(H3)`
 
 const Subtitle = styled(Text)`
   color: ${color.foregroundMuted};
+  text-wrap: balance;
 `
 
 interface Props {


### PR DESCRIPTION
Modern browsers are starting to [support](https://caniuse.com/?search=text-wrap) `text-wrap: balance`, so I added it to the two components I could think of, the Cover and Prompt.

[It spreads out words across multiple lines](https://developer.chrome.com/blog/css-text-wrap-balance/), here it is in action:

| Without | With |
| ----------- | ----------- |
| ![Screenshot 2023-06-13 at 14 20 08](https://github.com/TicketSwap/solar/assets/6670305/628f08eb-2906-4c0d-92a1-1e511e251081) | ![Screenshot 2023-06-13 at 14 20 13](https://github.com/TicketSwap/solar/assets/6670305/d78417c6-295e-45d2-8376-e3ca7a902c85) |


