### PR TITLE
fix(CoverV2): Only use gradient overlay when there is a background

### DIFF
--- a/src/components/CoverV2/Cover.tsx
+++ b/src/components/CoverV2/Cover.tsx
@@ -101,19 +101,23 @@ const CoverBackgroundImage = styled.div<CoverBackgroundImageProps>`
       }
     `};
 
-  &:after {
-    content: '';
-    position: absolute;
-    block-size: 100%;
-    inline-size: 100%;
-    inset-inline: 0;
-    inset-block-start: 0;
-    background: linear-gradient(
-      180deg,
-      rgba(26, 33, 41, 0.4) 0%,
-      rgba(26, 33, 41, 0.8) 100%
-    );
-  }
+  ${({ defaultImage }) =>
+    defaultImage &&
+    css`
+      &:after {
+        content: '';
+        position: absolute;
+        block-size: 100%;
+        inline-size: 100%;
+        inset-inline: 0;
+        inset-block-start: 0;
+        background: linear-gradient(
+          180deg,
+          rgba(26, 33, 41, 0.4) 0%,
+          rgba(26, 33, 41, 0.8) 100%
+        );
+      }
+    `}
 `
 
 const CoverContent = styled.div`


### PR DESCRIPTION
# Description

When there is no background image you can use a color as background. However, this was not looking great because the gradient overlay was still applied. This PR makes sure that this doesn't happen if there is no background image.

## How to test

- Checkout this branch
- `yarn storybook`
- Go to the `CoverV2` stories
- Check out the stories, Verify they work as expected
