### PR TITLE
`Heading` tweaks

### DIFF
--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -3,7 +3,7 @@ import { color, device, fontSize, fontWeight, lineHeight } from '../../theme'
 
 export const H1 = styled.h1`
   font-weight: ${fontWeight.bold};
-  font-size: ${fontSize[28]};
+  font-size: ${fontSize[32]};
   line-height: ${lineHeight.title};
 
   @media ${device.tablet} {

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -5,6 +5,7 @@ export const H1 = styled.h1`
   font-weight: ${fontWeight.bold};
   font-size: ${fontSize[32]};
   line-height: ${lineHeight.title};
+  text-wrap: balance;
 
   @media ${device.tablet} {
     font-size: ${fontSize[56]};
@@ -16,6 +17,7 @@ export const H2 = styled.h2`
   font-weight: ${fontWeight.bold};
   font-size: ${fontSize[24]};
   line-height: ${lineHeight.title};
+  text-wrap: balance;
 
   @media ${device.tablet} {
     font-size: ${fontSize[32]};


### PR DESCRIPTION
The hierarchy between the H1 and H2 was a bit hard to spot on mobile because the difference was very small, so increased the size of the H1 a bit on mobile.

While I was at it I also added `text-wrap: balance` to H1 and H2. Bit less confident about adding it to the other headers, we can do that later.

| Old | New|
|-----|-----|
| ![Screenshot 2023-06-19 at 10 18 56](https://github.com/TicketSwap/solar/assets/6670305/a7a1fce0-bcb4-421c-bcc0-af2188d26281) | ![Screenshot 2023-06-19 at 10 19 15](https://github.com/TicketSwap/solar/assets/6670305/fcdc4cc0-e237-4b78-a331-9e904eda241e) |
| ![Screenshot 2023-06-19 at 10 19 47](https://github.com/TicketSwap/solar/assets/6670305/30b2e9c9-1dd8-4000-84dc-0b3d4d1a50e4) | ![Screenshot 2023-06-19 at 10 20 05](https://github.com/TicketSwap/solar/assets/6670305/085c1829-2293-40e8-bf4a-e8d24e9603f2) |

