### PR TITLE
Tweak `StylisedIcon` colours

### DIFF
--- a/src/components/StylisedIcon/StylisedIcon.tsx
+++ b/src/components/StylisedIcon/StylisedIcon.tsx
@@ -19,12 +19,10 @@ interface IconBackgroundProps {
 }
 
 const IconBackground = styled.div<IconBackgroundProps>`
-  background-color: var(
-    --_stylisedIconBackgroundColor,
-    ${color.elevatedBackground}
-  );
+  color: var(--_stylisedIconColor, ${color.foregroundMuted});
+  border: 1px solid currentColor;
+  opacity: 0.25;
   border-radius: 50%;
-  opacity: 0.6;
   padding: ${space[16]};
   inline-size: var(--_stylisedIconBackgroundSize, ${space[64]});
   block-size: var(--_stylisedIconBackgroundSize, ${space[64]});
@@ -37,9 +35,15 @@ const IconBackground = styled.div<IconBackgroundProps>`
     block-size: var(--_stylisedIconIconSize, ${space[24]});
     max-inline-size: var(--_stylisedIconIconSize, ${space[24]});
     max-block-size: var(--_stylisedIconIconSize, ${space[24]});
+  }
 
-    svg {
-      color: var(--_stylisedIconIconColor, ${color.foregroundMuted});
+  @supports (background-color: color-mix(in srgb, currentColor, transparent)) {
+    border: none;
+    opacity: 1;
+    background-color: color-mix(in srgb, currentColor, transparent 88%);
+
+    > span {
+      opacity: 0.5;
     }
   }
 
@@ -63,8 +67,7 @@ const IconBackground = styled.div<IconBackgroundProps>`
   ${({ variant }) =>
     variant === 'light' &&
     css`
-      --_stylisedIconBackgroundColor: ${color.lightElevatedBackground};
-      --_stylisedIconIconColor: ${color.darkForegroundMuted};
+      --_stylisedIconColor: ${color.lightForeground};
     `}
 `
 


### PR DESCRIPTION
The usage of semantic colours in the Stylised Icon was a bit of a mix and match, giving different results than intended.

This PR uses `color-mix` to fix that and clean up the variables. For browser that don't support color-mix I added a fallback with a stroke just in case.

| Old | New | Fallback |
| --- | --- | --- |
| ![Screenshot 2023-06-26 at 11 25 40](https://github.com/TicketSwap/solar/assets/6670305/1d048ad8-79e7-4bac-a483-f82d99552ab4) | ![Screenshot 2023-06-26 at 11 25 03](https://github.com/TicketSwap/solar/assets/6670305/c7a6c697-4276-4967-8ef3-c0d8f7cdd074) | ![Screenshot 2023-06-26 at 11 25 21](https://github.com/TicketSwap/solar/assets/6670305/56cc76b6-02fc-460f-9783-6082bdd80e03) |
| ![Screenshot 2023-06-26 at 11 25 43](https://github.com/TicketSwap/solar/assets/6670305/c444211a-cf82-4ba7-8e47-005731accbc0) | ![Screenshot 2023-06-26 at 11 25 08](https://github.com/TicketSwap/solar/assets/6670305/e69d2971-befd-4259-bbe6-4d5a81b1a3ad) | ![Screenshot 2023-06-26 at 11 25 17](https://github.com/TicketSwap/solar/assets/6670305/13bc0e26-151d-4b80-87b0-570303e1dfc1) |
