### PR TITLE
feat(StylisedIcon): Introduce success variant

### DIFF
--- a/src/components/StylisedIcon/StylisedIcon.tsx
+++ b/src/components/StylisedIcon/StylisedIcon.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/react'
 export enum StylisedIconVariant {
   default = 'default',
   light = 'light',
+  success = 'success',
 }
 
 export enum StylisedIconSize {
@@ -68,6 +69,12 @@ const IconBackground = styled.div<IconBackgroundProps>`
     variant === 'light' &&
     css`
       --_stylisedIconColor: ${color.lightForeground};
+    `}
+
+  ${({ variant }) =>
+    variant === 'success' &&
+    css`
+      --_stylisedIconColor: ${color.success};
     `}
 `
 

--- a/src/components/StylisedIcon/index.stories.tsx
+++ b/src/components/StylisedIcon/index.stories.tsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import { StylisedIcon } from '.'
-import { Event, Tag } from '../../icons'
+import { CheckmarkRounded, Event, Tag } from '../../icons'
 import { Cover } from '../CoverV2'
 
 export const Default = () => <StylisedIcon icon={<Event />} />
+
+export const Success = () => (
+  <StylisedIcon variant="success" icon={<CheckmarkRounded />} />
+)
 
 export const Large = () => <StylisedIcon size="large" icon={<Event />} />
 


### PR DESCRIPTION
# Description

This introduces the "success" variant for the stylised icon component.

## How to test

- Checkout this branch
- `$ yarn storybook`
- Go to the StylisedIcon component
- Open the `success` story
- Verify it works as expected

## Screenshots

<img width="919" alt="CleanShot 2023-06-27 at 12 52 16@2x" src="https://github.com/TicketSwap/solar/assets/14276144/e1595052-5a51-4683-8cee-ca649b6b1752">

