### PR TITLE
Add `displayLength` prop to toasts

### DIFF
--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -36,7 +36,7 @@ function WithAdornment() {
       onClick={() =>
         notify(() => (
           <Toast
-            persist
+            displayLength="persistent"
             leftAdornment={<CheckmarkRounded color={color.success} size={24} />}
           >
             Your preferences have been successfully updated
@@ -66,7 +66,7 @@ function WithInput() {
     <Button
       onClick={() =>
         notify(() => (
-          <Toast persist>
+          <Toast displayLength="persistent">
             <Select
               items={items}
               id="language"
@@ -91,7 +91,7 @@ function Persistent() {
     <Button
       onClick={() =>
         notify(remove => (
-          <Toast persist>
+          <Toast displayLength="persistent">
             <ToastContent>
               <span>Payment failed</span>
 
@@ -120,7 +120,7 @@ function PersistentWithAdornment() {
         onClick={() =>
           notify(remove => (
             <Toast
-              persist
+              displayLength="persistent"
               leftAdornment={
                 <CheckmarkRounded color={color.success} size={24} />
               }
@@ -146,7 +146,7 @@ function PersistentWithAdornment() {
         onClick={() =>
           notify(remove => (
             <Toast
-              persist
+              displayLength="persistent"
               leftAdornment={
                 <CheckmarkRounded color={color.success} size={24} />
               }
@@ -179,7 +179,9 @@ const WithDialog = () => {
             <DialogBody>
               <Button
                 onClick={() =>
-                  notify(() => <Toast persist>Notification</Toast>)
+                  notify(() => (
+                    <Toast displayLength="persistent">Notification</Toast>
+                  ))
                 }
               >
                 Show toast

--- a/src/components/Toast/index.stories.tsx
+++ b/src/components/Toast/index.stories.tsx
@@ -28,6 +28,20 @@ function Basic() {
   )
 }
 
+function BasicWithLongDisplayLength() {
+  const { notify } = useToast()
+
+  return (
+    <Button
+      onClick={() =>
+        notify(() => <Toast displayLength="long">Notification</Toast>)
+      }
+    >
+      Show toast
+    </Button>
+  )
+}
+
 function WithAdornment() {
   const { notify } = useToast()
 
@@ -195,6 +209,9 @@ const WithDialog = () => {
 }
 
 export const BasicToast = () => <Basic />
+export const BasicToastWithLongDisplayLength = () => (
+  <BasicWithLongDisplayLength />
+)
 export const WithAdornmentToast = () => <WithAdornment />
 export const WithInputToast = () => <WithInput />
 export const PersistentToast = () => <Persistent />


### PR DESCRIPTION
# Description

This will make it possible to have different timeouts/durations for showing toasts. The default is 3 seconds, which is fine for most toasts but sometimes you have a toast that's a bit longer to read and then it would be nice to have a bit longer duration, without making the toast persistent. 

## How to test

- Checkout this branch
- `yarn storybook`
- Go to the toast stories
- Verify the basic one is showing for 3 seconds
- Verify the long displayLength story is showing for 5 seconds
