### PR TITLE
feat(CoverV2): Add tag as property

### DIFF
--- a/src/components/CoverV2/Cover.tsx
+++ b/src/components/CoverV2/Cover.tsx
@@ -180,6 +180,10 @@ const Graphic = styled.div`
   }
 `
 
+const Tag = styled.div`
+  margin-block-end: ${space[8]};
+`
+
 const MetaInfo = styled.div`
   max-width: 100%;
 
@@ -198,6 +202,7 @@ interface CoverProps {
   title: string
   subtitle?: string | ReactElement
   images?: CoverImages
+  tag?: ReactElement
   graphic?: ReactElement
   metaInfo?: ReactElement
   actions?: ReactElement
@@ -206,6 +211,7 @@ interface CoverProps {
 
 export const Cover = ({
   images,
+  tag,
   title,
   subtitle,
   graphic,
@@ -230,6 +236,8 @@ export const Cover = ({
 
       <CoverContent>
         {graphic && <Graphic>{graphic}</Graphic>}
+
+        {tag && <Tag>{tag}</Tag>}
 
         <Titles>
           <Title>{title}</Title>

--- a/src/components/CoverV2/index.stories.tsx
+++ b/src/components/CoverV2/index.stories.tsx
@@ -6,6 +6,7 @@ import {
   Calendar,
   ChevronRightAlt,
   Clock,
+  Event,
   MusicalNote,
   PlusAlt,
   Tag,
@@ -35,6 +36,10 @@ const Image = styled.img`
   width: 100%;
   max-inline-size: 375px;
   object-fit: cover;
+`
+
+const TagLabel = styled.span`
+  color: ${color.lightForeground};
 `
 
 const StyledCover = styled(Cover)`
@@ -94,6 +99,28 @@ export const withImageGraphic = () => (
   <Cover
     title="Pop"
     subtitle="Discover our pop content"
+    images={{
+      desktop:
+        'https://cdn.ticketswap.com/public/202211/zwarte-cross-2023-zwarte-cross-20-july-2023-1667298561.image.jpeg',
+    }}
+    graphic={
+      <Image
+        src="https://cdn.ticketswap.com/public/202211/zwarte-cross-2023-zwarte-cross-20-july-2023-1667298561.image.jpeg"
+        alt="Pop image"
+      />
+    }
+  />
+)
+
+export const withTag = () => (
+  <Cover
+    title="Pop"
+    subtitle="Discover our pop content"
+    tag={
+      <TagLabel>
+        <Event size={20} /> Partnered events
+      </TagLabel>
+    }
     images={{
       desktop:
         'https://cdn.ticketswap.com/public/202211/zwarte-cross-2023-zwarte-cross-20-july-2023-1667298561.image.jpeg',


### PR DESCRIPTION
# Description

See title! This makes it possible to add additional taglines to the cover, such as "Partnered events", "Amsterdam Dance Event", etc.

## How to test

- Checkout this branch
- `yarn storybook`
- Verify the new WithTag story is working as expected