### PR TITLE
build(build): force minimum node version 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "scripts": {
     "commit": "git-cz",


### PR DESCRIPTION
BREAKING CHANGE: Updating the node engine of Solar

# Description

This PR sets the minimum node version to 18

## How to test

- Checkout PR
- Create a build
- Confirm all goes well