### PR TITLE
fix(BaseButton): use action color instead of info color

### DIFF
--- a/src/components/BaseButton/index.tsx
+++ b/src/components/BaseButton/index.tsx
@@ -39,7 +39,7 @@ const StyledButton = styled.button<ButtonProps>`
       ? color.failure
       : props.variant === ButtonVariant.warning
       ? color.warning
-      : color.info};
+      : color.action};
   font-weight: ${fontWeight.semiBold};
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
 


### PR DESCRIPTION
# Description

The BaseButton was using the `info` color as default color, but since it's a button it should use the `action` color, which is the same but this makes it more semantic and improves theming.
