### PR TITLE
fix(chip): fix adornment height when spinner is used

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -77,7 +77,7 @@ const Container = styled.span<ContainerProps>`
 
       @media ${device.tablet} {
         > *:first-of-type:not(style) {
-          display: block;
+          display: flex;
         }
       }
     `}


### PR DESCRIPTION
# Description
When using a Spinner the height was not perfectly correct, which resulted in some layout issues. Changing it to a flex container fixes that issue,.