### PR TITLE
fix(chip): set place-items as initial as hides icons on safari

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -78,6 +78,7 @@ const Container = styled.span<ContainerProps>`
       @media ${device.tablet} {
         > *:first-of-type:not(style) {
           display: flex;
+          align-items: initial;
         }
       }
     `}


### PR DESCRIPTION
# Description

**Bug**: If you go on your safari browser desktop and would see all the filters show the space for the icon (startAdornment) but not the icon itself, where it would be okay on Chrome

**Solution**: Seems like the `place-items: center` was the issue. If setting it to initial, it will show on both browser

## How to test

- Downgrade your node engine to node 12 and your node version as well
- Delete `semantic-release` from your package.json
- Run `yarn; yarn storybook` 
- Go to chip > compact on chrome: should show a start adornment calendar icon on desktop but not on mobile desktop 
- Open your storybook on safari   > chip > compact > should show a start adornment calendar icon on desktop but not on mobile desktop 
- If you go back to main, on safari desktop you won't see the icons 
