### PR TITLE
fix: build step

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -14,7 +14,7 @@ module.exports = {
     '@babel/plugin-transform-runtime',
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-object-rest-spread',
+    '@babel/plugin-transform-object-rest-spread',
     '@babel/plugin-proposal-optional-chaining',
   ],
 }


### PR DESCRIPTION
This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. We should use
@babel/plugin-transform-object-rest-spread instead.
